### PR TITLE
reverting to last known functional state

### DIFF
--- a/frontend/src/components/PhysicsPanel.tsx
+++ b/frontend/src/components/PhysicsPanel.tsx
@@ -65,7 +65,7 @@ export const PhysicsPanel: React.FC = () => {
           label="Node Spacing"
           value={nodeSpacing}
           min="0"
-          max="500"
+          max="300"
           onChange={setNodeSpacing}
           displayValue={`${nodeSpacing} px`}
         />
@@ -73,7 +73,7 @@ export const PhysicsPanel: React.FC = () => {
           label="Drift Away Strength"
           value={driftAwayStrength * 100}
           min="0"
-          max="900"
+          max="500"
           onChange={(v: number) => setDriftAwayStrength(v / 100)}
           displayValue={driftAwayStrength.toFixed(2)}
         />
@@ -81,7 +81,7 @@ export const PhysicsPanel: React.FC = () => {
           label="Connection Pull"
           value={connectionPullStrength * 100}
           min="0"
-          max="900"
+          max="500"
           onChange={(v: number) => setConnectionPullStrength(v / 100)}
           displayValue={connectionPullStrength.toFixed(2)}
         />

--- a/frontend/src/stores/physicsStore.ts
+++ b/frontend/src/stores/physicsStore.ts
@@ -18,12 +18,12 @@ export interface PhysicsSettings {
 }
 
 const defaultPhysics = {
-    connectionPullStrength: 5.00,
+    connectionPullStrength: 4.25,
     collisionRepulsion: 1.25,
     damping: 0.095,
-    connectionLifetime: 2000,
+    connectionLifetime: 3000,
     nodeSpacing: 135,
-    driftAwayStrength: 3.0,
+    driftAwayStrength: 2.0,
 }
 
 export const usePhysicsStore = create<PhysicsSettings>()(


### PR DESCRIPTION
The following pull request introduces reverts these files to their last known good configuration on 2025-06-11:

- reverts /frontend/src/components/PhysicsPanel.tsx 
- reverts /frontend/src/stores/physicsStore.ts

No changes related to network were found in the following files: 

- frontend/src/components/CanvasNetworkRenderer.tsx
- frontend/src/hooks/useNetworkStore.ts
- frontend/src/stores/networkStore.ts
- frontend/src/stores/networkStore.ts.bak
- frontend/src/types/network.ts