### PR TITLE
feat: add experimental node sizing and edge width controls

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@pixi/react": "latest",
         "@types/lodash": "^4.17.16",
         "ip-address": "^10.0.1",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "pixi.js": "latest",
         "prismjs": "^1.30.0",
         "react": "latest",
@@ -86,6 +86,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -570,6 +571,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -770,6 +772,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -1693,9 +1696,10 @@
       "dev": true
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -1938,6 +1942,7 @@
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.10.1.tgz",
       "integrity": "sha512-wjKJXawhTUxuyKIuwE3jK05eBh5I4GKy+YrRVniURFRkK7pYEvRvnV41dEqz6owSXav/YMXdG5783YDJeamiow==",
+      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",
@@ -1974,6 +1979,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2131,6 +2137,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2139,6 +2146,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -2663,6 +2671,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.11.tgz",
       "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",
@@ -2913,6 +2922,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -3265,6 +3275,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3391,6 +3402,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
       "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3967,9 +3979,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -4148,6 +4160,7 @@
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.10.1.tgz",
       "integrity": "sha512-wjKJXawhTUxuyKIuwE3jK05eBh5I4GKy+YrRVniURFRkK7pYEvRvnV41dEqz6owSXav/YMXdG5783YDJeamiow==",
+      "peer": true,
       "requires": {
         "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",
@@ -4166,6 +4179,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
       "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4241,12 +4255,14 @@
     "react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true
     },
     "react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "requires": {
         "scheduler": "^0.26.0"
       }
@@ -4611,6 +4627,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.11.tgz",
       "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",

--- a/frontend/src/components/CanvasNetworkRenderer.tsx
+++ b/frontend/src/components/CanvasNetworkRenderer.tsx
@@ -3,6 +3,7 @@ import { useSizeStore } from '../stores/sizeStore';
 import { useGraphLayout, WORLD_SCALE, camera } from '../hooks/useGraphLayout';
 import { useThemeStore, subnetNodeColor, edgeColor, Theme } from '../stores/themeStore';
 import { usePinStore } from '../stores/pinStore';
+import { usePhysicsStore } from '../stores/physicsStore';
 
 // Start zoomed out so the whole (larger-than-viewport) world fits, leaving real
 // room to zoom in. zoom = 1/WORLD_SCALE with pan (0,0) maps world → viewport 1:1.
@@ -24,9 +25,16 @@ export const CanvasNetworkRenderer: React.FC = React.memo(() => {
   // Active theme read per-frame via a ref so switching recolors instantly
   // with zero React re-renders in the render loop.
   const themeRef = useRef<Theme>(useThemeStore.getState().theme);
+  const physicsRef = useRef(usePhysicsStore.getState());
   useEffect(() => {
     themeRef.current = useThemeStore.getState().theme;
-    return useThemeStore.subscribe(s => { themeRef.current = s.theme; });
+    physicsRef.current = usePhysicsStore.getState();
+    const unsubTheme = useThemeStore.subscribe(s => { themeRef.current = s.theme; });
+    const unsubPhysics = usePhysicsStore.subscribe(s => { physicsRef.current = s; });
+    return () => {
+      unsubTheme();
+      unsubPhysics();
+    };
   }, []);
 
   // ── Canvas resize ───────────────────────────────────────────────────────────
@@ -89,23 +97,33 @@ export const CanvasNetworkRenderer: React.FC = React.memo(() => {
       edgeDegree.set(edge.targetId, (edgeDegree.get(edge.targetId) ?? 0) + 1);
     });
 
+    const { edgeWidthIntensity } = physicsRef.current;
+    const edgeI = Math.max(0, Math.min(1, edgeWidthIntensity));
+
     // ── Draw edges ──────────────────────────────────────────────────────────
     // Budget for port labels shown at the zoomed-out overview (interesting
     // edges only) so scan ports read without diving all the way in.
     let portLabels = 0;
     const portLabelBoxes: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
-    edges.forEach(edge => {
+
+    // Throughput width only changes stroke thickness — not opacity — so quiet
+    // links stay visible. Draw thin→thick so hot pipes sit on top.
+    const drawEdges = edgeI > 0
+      ? Array.from(edges).sort((a, b) => a.weight - b.weight)
+      : Array.from(edges);
+    drawEdges.forEach(edge => {
       const src = nodes.get(edge.sourceId);
       const tgt = nodes.get(edge.targetId);
       if (!src || !tgt || edge.alpha <= 0) return;
 
       const proto = edge.protocol?.toLowerCase() ?? '';
       const degree = Math.max(edgeDegree.get(edge.sourceId) ?? 1, edgeDegree.get(edge.targetId) ?? 1);
-      const degreeAlpha = Math.max(0.5, Math.min(1, Math.sqrt(24 / degree)));
-      const weightBoost = Math.max(0.75, Math.min(1.4, Math.sqrt(edge.weight)));
-      const edgeAlpha = Math.min(1, edge.alpha * degreeAlpha * weightBoost);
-      const weightedWidth = Math.max(1, Math.min(4, 1 + Math.log1p(edge.weight)));
-      const lineWidth = proto === 'icmp' ? Math.max(1, weightedWidth - 0.75) : weightedWidth;
+      const classicDegreeAlpha = Math.max(0.5, Math.min(1, Math.sqrt(24 / degree)));
+      const classicWeightBoost = Math.max(0.75, Math.min(1.4, Math.sqrt(edge.weight)));
+      // Classic edge alpha only (no experimental quiet-link fade).
+      const edgeAlpha = Math.min(1, edge.alpha * classicDegreeAlpha * classicWeightBoost);
+      const weightedWidth = edge.thickness ?? Math.max(1, Math.min(4, 1 + Math.log1p(edge.weight)));
+      const lineWidth = proto === 'icmp' ? Math.max(1, weightedWidth * 0.7) : weightedWidth;
 
       ctx.strokeStyle = edgeColor(proto, edgeAlpha, theme);
       ctx.lineWidth   = lineWidth;
@@ -161,9 +179,10 @@ export const CanvasNetworkRenderer: React.FC = React.memo(() => {
     // stands out as the thing to watch.
     let anyFocus = false;
     nodes.forEach(n => { if (n.focus) anyFocus = true; });
-    nodes.forEach(node => {
-      if (node.alpha <= 0) return;
 
+    const drawNodes = Array.from(nodes.values()).filter(n => n.alpha > 0);
+
+    for (const node of drawNodes) {
       const hr = parseInt(node.highlightColor.slice(1, 3), 16);
       const hg = parseInt(node.highlightColor.slice(3, 5), 16);
       const hb = parseInt(node.highlightColor.slice(5, 7), 16);
@@ -172,23 +191,23 @@ export const CanvasNetworkRenderer: React.FC = React.memo(() => {
       const isFocus = node.focus;
       const isConnected = connectedIds.has(node.id) || node.pinned || isFocus;
       const dimBulk = anyFocus && !isFocus && !node.pinned;
+
       const visualAlpha = isFocus ? 1
         : isConnected ? node.alpha * (dimBulk ? 0.34 : 1)
         : node.alpha * (anyFocus ? 0.1 : 0.35);
+      const talkBright = isConnected ? 1 : 0.35;
+      const bodyColor = subnetNodeColor(node.clusterKey, isFocus ? 1 : talkBright, theme);
 
-      // Node fill: per-subnet hue from the active theme, brighter when talking.
-      // This is what makes subnet blobs read as coherent color groups.
-      const bodyColor = subnetNodeColor(node.clusterKey, isConnected ? 1 : 0.35, theme);
-
-      // Glow ring — always for focus nodes (stronger), plus active nodes.
-      if (isFocus || (node.radius > 7 && isConnected && !dimBulk)) {
-        ctx.fillStyle = `rgba(${hr},${hg},${hb},${(isFocus ? 0.45 : visualAlpha * 0.3)})`;
+      const showGlow = isFocus || (node.radius > 7 && isConnected && !dimBulk);
+      if (showGlow) {
+        const glowAlpha = isFocus ? 0.45 : visualAlpha * 0.3;
+        const glowScale = isFocus ? 2.2 : 1.5;
+        ctx.fillStyle = `rgba(${hr},${hg},${hb},${glowAlpha})`;
         ctx.beginPath();
-        ctx.arc(node.x, node.y, node.radius * (isFocus ? 2.2 : 1.5), 0, Math.PI * 2);
+        ctx.arc(node.x, node.y, node.radius * glowScale, 0, Math.PI * 2);
         ctx.fill();
       }
 
-      // Node body (focus nodes drawn larger so the star pops)
       const bodyR = isFocus ? node.radius * 1.5 : isConnected ? node.radius : node.radius * 0.7;
       ctx.globalAlpha = visualAlpha;
       ctx.fillStyle   = bodyColor;
@@ -197,12 +216,12 @@ export const CanvasNetworkRenderer: React.FC = React.memo(() => {
       ctx.fill();
       ctx.globalAlpha = 1;
 
-      // Label connected nodes (the active conversations). Font is constant on
-      // screen regardless of zoom; overlapping labels are always dropped, so
-      // the overview shows a clean sparse set and detail fills in on zoom-in.
-      // Cap labels per frame: canvas fillText/measureText is costly, and at
-      // wide spacing few labels overlap (so many would draw). Bound it.
-      if ((isFocus || labelBoxes.length < 140) && isConnected && node.id.includes('.') && vp.zoom >= labelZoomThreshold) {
+      if (
+        (isFocus || labelBoxes.length < 140) &&
+        isConnected &&
+        node.id.includes('.') &&
+        vp.zoom >= labelZoomThreshold
+      ) {
         const fontSize = labelScreenPx / vp.zoom; // constant screen px
         ctx.font      = `${fontSize}px monospace`;
         ctx.textAlign = 'center';
@@ -221,14 +240,14 @@ export const CanvasNetworkRenderer: React.FC = React.memo(() => {
           labelBox.y1 < box.y2 &&
           labelBox.y2 > box.y1
         );
-        if (overlapsLabel) return; // always cull overlaps → clean at every zoom
+        if (overlapsLabel) continue; // always cull overlaps → clean at every zoom
         labelBoxes.push(labelBox);
         ctx.fillStyle = 'rgba(0,0,0,0.7)';
         ctx.fillRect(labelBox.x1, labelBox.y1, tw + pad * 2, fontSize + pad * 2);
         ctx.fillStyle = `rgba(${hr},${hg},${hb},${node.alpha})`;
         ctx.fillText(node.id, node.x, textY);
       }
-    });
+    }
 
     ctx.textAlign = 'left';
     ctx.restore();

--- a/frontend/src/components/PhysicsPanel.tsx
+++ b/frontend/src/components/PhysicsPanel.tsx
@@ -10,11 +10,15 @@ interface RangeSliderProps {
   step?: string | number;
   onChange: (value: number) => void;
   displayValue: string;
+  hint?: string;
 }
 
-const RangeSlider: React.FC<RangeSliderProps> = ({ label, value, min, max, step, onChange, displayValue }) => (
+const RangeSlider: React.FC<RangeSliderProps> = ({ label, value, min, max, step, onChange, displayValue, hint }) => (
   <div>
     <label>{label}</label>
+    {hint && (
+      <div style={{ fontSize: '11px', opacity: 0.65, marginBottom: '4px' }}>{hint}</div>
+    )}
     <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
       <input
         type="range"
@@ -43,6 +47,8 @@ export const PhysicsPanel: React.FC = () => {
     driftAwayStrength,
     centerPullStrength,
     springRestLength,
+    nodeSizingIntensity,
+    edgeWidthIntensity,
     setConnectionPullStrength,
     setCollisionRepulsion,
     setDamping,
@@ -52,11 +58,13 @@ export const PhysicsPanel: React.FC = () => {
     setDriftAwayStrength,
     setCenterPullStrength,
     setSpringRestLength,
+    setNodeSizingIntensity,
+    setEdgeWidthIntensity,
     resetPhysicsDefaults,
   } = usePhysicsStore();
 
   return (
-    <div style={{ marginTop: '20px' }}>
+    <div style={{ marginTop: '12px', paddingBottom: '12px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
         <h3>Physics Controls</h3>
         <button
@@ -151,6 +159,43 @@ export const PhysicsPanel: React.FC = () => {
           displayValue={`${springRestLength} px`}
         />
       </div>
+
+      {/* ── Experimental ─────────────────────────────────────────────────── */}
+      <div
+        style={{
+          marginTop: '28px',
+          paddingTop: '16px',
+          borderTop: '1px solid rgba(0, 255, 0, 0.25)',
+        }}
+      >
+        <h3 style={{ marginBottom: '6px' }}>Experimental</h3>
+        <p style={{ fontSize: '11px', opacity: 0.65, marginBottom: '14px' }}>
+          Ball size = connections. Line width = throughput. 0% = off / regular.
+        </p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '14px' }}>
+          <RangeSlider
+            label="Connection-count sizing"
+            hint="Ball size grows with number of connections"
+            value={Math.round(nodeSizingIntensity * 100)}
+            min="0"
+            max="100"
+            step="1"
+            onChange={(v) => setNodeSizingIntensity(v / 100)}
+            displayValue={`${Math.round(nodeSizingIntensity * 100)}%`}
+          />
+          <RangeSlider
+            label="Throughput line width"
+            hint="Line thickness follows sustained throughput"
+            value={Math.round(edgeWidthIntensity * 100)}
+            min="0"
+            max="100"
+            step="1"
+            onChange={(v) => setEdgeWidthIntensity(v / 100)}
+            displayValue={`${Math.round(edgeWidthIntensity * 100)}%`}
+          />
+        </div>
+      </div>
     </div>
   );
-}; 
+};

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -52,8 +52,17 @@ export const SettingsPanel: React.FC<{
     e.stopPropagation();
   };
 
+  const handlePanelWheel = (e: React.WheelEvent) => {
+    // Keep scroll inside the panel; don't zoom/pan the canvas underneath.
+    e.stopPropagation();
+  };
+
   return (
-    <div className="settings-panel" onMouseDown={handlePanelMouseDown}>
+    <div
+      className="settings-panel"
+      onMouseDown={handlePanelMouseDown}
+      onWheel={handlePanelWheel}
+    >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <h2>Settings</h2>
         <button onClick={onMinimize} className="minimize-btn">_</button>

--- a/frontend/src/hooks/useGraphLayout.ts
+++ b/frontend/src/hooks/useGraphLayout.ts
@@ -4,6 +4,12 @@ import { usePhysicsStore } from '../stores/physicsStore';
 import { useSettingsStore } from '../stores/settingsStore';
 import { usePinStore } from '../stores/pinStore';
 import { useSizeStore } from '../stores/sizeStore';
+import {
+  NODE_RADIUS_MAX,
+  NODE_RADIUS_MIN,
+  calculateRelativeEdgeWidth,
+  calculateRelativeNodeRadius,
+} from '../utils/messageUtils';
 
 export interface LayoutNode {
   id: string;
@@ -16,6 +22,10 @@ export interface LayoutNode {
   clusterKey: string;
   radius: number;
   effectiveRadius: number;
+  /** 0..1 share of heaviest visible node's connection count (drives ball size). */
+  load: number;
+  /** Live connection count used for sizing. */
+  degree: number;
   color: string;
   highlightColor: string;
   alpha: number;
@@ -33,6 +43,8 @@ export interface LayoutEdge {
   dstPort?: number;
   alpha: number;
   weight: number;
+  /** Stroke width derived from peer-relative sustained weight. */
+  thickness: number;
   lastActive: number;
 }
 
@@ -44,7 +56,9 @@ export interface GraphLayoutResult {
 
 const PHYSICS_HZ = 30;
 const PHYSICS_STEP = 1000 / PHYSICS_HZ;
-const NODE_RADIUS = 8;
+const NODE_RADIUS = NODE_RADIUS_MIN + 2;
+/** How quickly radius eases toward the throughput target (per sync). */
+const RADIUS_SMOOTH = 0.22;
 // A pinned node with no live connection for this long fades out and is removed
 // (the pin RULE stays — it re-docks if the host talks again).
 const PIN_IDLE_MS = 60000;
@@ -339,6 +353,8 @@ export function useGraphLayout(): GraphLayoutResult {
           clusterKey,
           radius: NODE_RADIUS,
           effectiveRadius: NODE_RADIUS,
+          load: 0,
+          degree: 0,
           color: getProtocolColor(c.protocol),
           highlightColor: getHighlightColor(id),
           alpha: 1,
@@ -351,22 +367,68 @@ export function useGraphLayout(): GraphLayoutResult {
       }
     }
 
+    const {
+      nodeSizingIntensity,
+      edgeWidthIntensity,
+    } = physicsRef.current;
+    const sizingI = Math.max(0, Math.min(1, nodeSizingIntensity));
+    const edgeI = Math.max(0, Math.min(1, edgeWidthIntensity));
+
+    // Peer-relative edge thickness from sustained (decayed) weight.
+    let maxEdgeWeight = 0;
+    for (const c of visibleConns) {
+      if (!layoutNodes.current.has(c.source) || !layoutNodes.current.has(c.target)) continue;
+      const w = c.weight ?? 1;
+      if (w > maxEdgeWeight) maxEdgeWeight = w;
+    }
+    if (maxEdgeWeight <= 0) maxEdgeWeight = 1;
+
     layoutEdges.current = visibleConns
       .filter(c =>
         layoutNodes.current.has(c.source) &&
         layoutNodes.current.has(c.target)
       )
-      .map(c => ({
-        id: c.id,
-        sourceId: c.source,
-        targetId: c.target,
-        color: c.packetColor ?? getProtocolColor(c.protocol),
-        protocol: c.protocol,
-        dstPort: c.dstPort,
-        alpha: Math.max(0, 1 - (now - c.lastActive) / connectionLifetime),
-        weight: c.weight ?? 1,
-        lastActive: c.lastActive,
-      }));
+      .map(c => {
+        const weight = c.weight ?? 1;
+        const classicWidth = Math.max(1, Math.min(4, 1 + Math.log1p(weight)));
+        const relativeWidth = calculateRelativeEdgeWidth(weight / maxEdgeWeight);
+        const thickness = classicWidth + (relativeWidth - classicWidth) * edgeI;
+        return {
+          id: c.id,
+          sourceId: c.source,
+          targetId: c.target,
+          color: c.packetColor ?? getProtocolColor(c.protocol),
+          protocol: c.protocol,
+          dstPort: c.dstPort,
+          alpha: Math.max(0, 1 - (now - c.lastActive) / connectionLifetime),
+          weight,
+          thickness,
+          lastActive: c.lastActive,
+        };
+      });
+
+    // Experimental mapping (per-intensity):
+    //   ball size  → connection count (degree)
+    //   line width → throughput (edge weight) — set above
+    const degreeById = new Map<string, number>();
+    for (const edge of layoutEdges.current) {
+      degreeById.set(edge.sourceId, (degreeById.get(edge.sourceId) ?? 0) + 1);
+      degreeById.set(edge.targetId, (degreeById.get(edge.targetId) ?? 0) + 1);
+    }
+    let maxDegree = 0;
+    for (const deg of degreeById.values()) if (deg > maxDegree) maxDegree = deg;
+    if (maxDegree <= 0) maxDegree = 1;
+
+    layoutNodes.current.forEach(node => {
+      const degree = degreeById.get(node.id) ?? 0;
+      const degRel = degree / maxDegree;
+      node.degree = degree;
+      node.load = sizingI > 0 ? degRel : 0;
+      const sizedRadius = calculateRelativeNodeRadius(degRel, NODE_RADIUS_MIN, NODE_RADIUS_MAX);
+      const targetRadius = NODE_RADIUS + (sizedRadius - NODE_RADIUS) * sizingI;
+      node.radius += (targetRadius - node.radius) * RADIUS_SMOOTH;
+      node.effectiveRadius = node.radius;
+    });
   }, []);
 
   const tickLayout = useCallback((dt: number) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,7 +29,45 @@ body {
   color: var(--vibes-primary, #00ff00);
   font-family: 'VT323', monospace;
   z-index: 1000;
-  width: 320px;
+  width: 340px;
+  min-width: 280px;
+  min-height: 220px;
+  max-width: calc(100vw - 40px);
+  /* Leave room for status/command bar; Physics + Experimental used to clip. */
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  resize: both;
+}
+
+.settings-panel > div:first-child,
+.settings-panel > .button-group {
+  flex-shrink: 0;
+}
+
+.settings-panel .tab-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 6px;
+  margin-right: -2px;
+}
+
+/* Subtle scrollbar so long Physics / Experimental lists stay usable */
+.settings-panel .tab-content::-webkit-scrollbar {
+  width: 8px;
+}
+.settings-panel .tab-content::-webkit-scrollbar-track {
+  background: rgba(0, 0, 0, 0.35);
+}
+.settings-panel .tab-content::-webkit-scrollbar-thumb {
+  background: rgba(var(--vibes-primary-rgb, 0, 255, 0), 0.45);
+  border-radius: 4px;
+}
+.settings-panel .tab-content::-webkit-scrollbar-thumb:hover {
+  background: rgba(var(--vibes-primary-rgb, 0, 255, 0), 0.75);
 }
 
 .settings-panel h2 {

--- a/frontend/src/stores/physicsStore.ts
+++ b/frontend/src/stores/physicsStore.ts
@@ -1,6 +1,14 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
+const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+
+const boolOrNumToIntensity = (v: unknown, fallback: number): number => {
+  if (typeof v === 'boolean') return v ? 1 : 0;
+  if (typeof v === 'number' && Number.isFinite(v)) return clamp01(v);
+  return fallback;
+};
+
 export interface PhysicsSettings {
   connectionPullStrength: number;
   collisionRepulsion: number;
@@ -11,6 +19,11 @@ export interface PhysicsSettings {
   driftAwayStrength: number;
   centerPullStrength: number;
   springRestLength: number;
+  // ── Experimental feature intensities (0 = off / classic, 1 = full) ───────
+  /** Ball size from connection count (degree). */
+  nodeSizingIntensity: number;
+  /** Line width from sustained throughput. */
+  edgeWidthIntensity: number;
   setConnectionPullStrength: (v: number) => void;
   setCollisionRepulsion: (v: number) => void;
   setDamping: (v: number) => void;
@@ -20,6 +33,8 @@ export interface PhysicsSettings {
   setDriftAwayStrength: (v: number) => void;
   setCenterPullStrength: (v: number) => void;
   setSpringRestLength: (v: number) => void;
+  setNodeSizingIntensity: (v: number) => void;
+  setEdgeWidthIntensity: (v: number) => void;
   resetPhysicsDefaults: () => void;
 }
 
@@ -33,10 +48,12 @@ const defaultPhysics = {
   driftAwayStrength: 2.4,
   centerPullStrength: 0.002, // weak territorial bias toward each node's subnet home
   springRestLength: 70,
+  nodeSizingIntensity: 1,
+  edgeWidthIntensity: 1,
 }
 
-// Increment to force-reset localStorage when defaults change
-const PHYSICS_VERSION = 21;
+// Increment to force-reset / migrate localStorage when settings shape changes
+const PHYSICS_VERSION = 26;
 
 export const usePhysicsStore = create<PhysicsSettings>()(
   persist(
@@ -51,6 +68,8 @@ export const usePhysicsStore = create<PhysicsSettings>()(
       setDriftAwayStrength: (v) => set({ driftAwayStrength: v }),
       setCenterPullStrength: (v) => set({ centerPullStrength: v }),
       setSpringRestLength: (v) => set({ springRestLength: v }),
+      setNodeSizingIntensity: (v) => set({ nodeSizingIntensity: clamp01(v) }),
+      setEdgeWidthIntensity: (v) => set({ edgeWidthIntensity: clamp01(v) }),
       resetPhysicsDefaults: () => set({ ...defaultPhysics }),
     }),
     {
@@ -59,7 +78,34 @@ export const usePhysicsStore = create<PhysicsSettings>()(
       storage: createJSONStorage(() => localStorage),
       migrate: (persistedState: any, version: number) => {
         if (version < PHYSICS_VERSION) {
-          return { ...defaultPhysics };
+          const prev = persistedState ?? {};
+          const {
+            klipperMode: _km,
+            klipperIntensity: _ki,
+            klipperThroughputSizing,
+            klipperEdgeThickness,
+            klipperDimQuiet: _kd,
+            klipperEnhanceBusy: _keb,
+            klipperSizingIntensity,
+            klipperEdgeIntensity,
+            klipperDimIntensity: _kdi,
+            klipperEnhanceIntensity: _kei,
+            dimQuietIntensity: _dd,
+            enhanceBusyIntensity: _eb,
+            ...rest
+          } = prev;
+          return {
+            ...defaultPhysics,
+            ...rest,
+            nodeSizingIntensity: boolOrNumToIntensity(
+              prev.nodeSizingIntensity ?? klipperSizingIntensity ?? klipperThroughputSizing,
+              1,
+            ),
+            edgeWidthIntensity: boolOrNumToIntensity(
+              prev.edgeWidthIntensity ?? klipperEdgeIntensity ?? klipperEdgeThickness,
+              1,
+            ),
+          };
         }
         return persistedState;
       },

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -10,6 +10,28 @@
   color: #00ff00;
   font-family: 'VT323', monospace;
   z-index: 1000;
+  width: 340px;
+  min-width: 280px;
+  min-height: 220px;
+  max-width: calc(100vw - 40px);
+  max-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  resize: both;
+}
+
+.settings-panel > div:first-child,
+.settings-panel > .button-group {
+  flex-shrink: 0;
+}
+
+.settings-panel .tab-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 6px;
 }
 
 .settings-panel h2 {

--- a/frontend/src/utils/messageUtils.ts
+++ b/frontend/src/utils/messageUtils.ts
@@ -34,21 +34,48 @@ export const formatDataSize = (bytes: number): string => {
   }
 }
 
+/** Visual node radius range in world units (Canvas layout). */
+export const NODE_RADIUS_MIN = 6
+export const NODE_RADIUS_MAX = 26
+
 /**
- * Calculates a node size based on traffic volume
- * Uses logarithmic scale to prevent huge nodes
+ * Maps absolute traffic volume → radius (legacy absolute scale).
+ * Prefer calculateRelativeNodeRadius for peer-relative sizing.
  */
 export const calculateNodeSize = (trafficVolume: number): number => {
-  // Base size is 10, max size is 50
-  const minSize = 10
-  const maxSize = 50
-  
+  const minSize = NODE_RADIUS_MIN
+  const maxSize = NODE_RADIUS_MAX
+
   if (trafficVolume <= 0) {
     return minSize
   }
-  
-  // Logarithmic scaling
+
   const size = minSize + (Math.log10(trafficVolume) * 5)
-  
   return Math.min(size, maxSize)
+}
+
+/**
+ * Peer-relative node radius: `relativeLoad` is this node's share of the
+ * heaviest visible talker (0..1). Sqrt softens winner-take-all spikes.
+ */
+export const calculateRelativeNodeRadius = (
+  relativeLoad: number,
+  minRadius = NODE_RADIUS_MIN,
+  maxRadius = NODE_RADIUS_MAX,
+): number => {
+  const t = Math.max(0, Math.min(1, relativeLoad))
+  return minRadius + (maxRadius - minRadius) * Math.sqrt(t)
+}
+
+/**
+ * Peer-relative edge stroke width from this edge's share of the heaviest
+ * visible flow (0..1). Quiet links stay thin; hot links read as pipes.
+ */
+export const calculateRelativeEdgeWidth = (
+  relativeWeight: number,
+  minWidth = 1,
+  maxWidth = 9,
+): number => {
+  const t = Math.max(0, Math.min(1, relativeWeight))
+  return minWidth + (maxWidth - minWidth) * Math.pow(t, 0.65)
 } 


### PR DESCRIPTION
## Summary
- Adds Physics → Experimental intensity sliders for peer-relative **node sizing** (by connection count) and **edge width** (by sustained throughput); `0%` = classic/off, `100%` = full effect.
- Makes the settings panel scrollable and resizable so Physics/Experimental controls fit on screen.
- Clamps persisted intensities and migrates older local settings keys safely.

Fixes #7

## Test plan
- [ ] Run frontend + backend locally with simulated traffic
- [ ] Open Settings → Physics → Experimental
- [ ] Set **Connection-count sizing** to 0% → nodes stay uniform; raise toward 100% → high-degree hosts grow vs peers
- [ ] Set **Throughput line width** to 0% → classic thin edges; raise toward 100% → hot flows thicken without fading quiet links away
- [ ] Confirm settings panel scrolls and can be resized; wheel scroll does not zoom the canvas
- [ ] Reload the page and confirm intensity values persist


Made with [Cursor](https://cursor.com)