### PR TITLE
refactor(theme): restore original curated Retro Blue color palette and UI chrome overrides

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,17 +19,17 @@ body {
 
 /* Retro Blue Neon Theme Overrides — disregards standard UI Kit when selected */
 [data-theme="retro-blue"] {
-  --card: rgba(4, 16, 40, 0.92);
-  --surface-card: rgba(4, 16, 40, 0.95);
-  --surface-chrome: #030a18;
-  --border-card: 1px solid #00ffff;
-  --border-control: 1px solid #00ffff;
-  --text-hi: #00ffff;
-  --signal-teal: #ff00ff;
-  --wash-ok: rgba(255, 0, 255, 0.25);
-  --vibes-primary: #00ffff;
-  --border-inset: 1px solid rgba(0, 255, 255, 0.4);
-  --text-muted: rgba(0, 255, 255, 0.7);
+  --card: rgba(4, 16, 31, 0.95);
+  --surface-card: rgba(4, 16, 31, 0.95);
+  --surface-chrome: #030b17;
+  --border-card: 1px solid rgba(51, 204, 255, 0.4);
+  --border-control: 1px solid rgba(56, 189, 248, 0.5);
+  --text-hi: #7dd3fc;
+  --signal-teal: #33ccff;
+  --wash-ok: rgba(51, 204, 255, 0.18);
+  --vibes-primary: #33ccff;
+  --border-inset: 1px solid rgba(51, 204, 255, 0.2);
+  --text-muted: rgba(125, 211, 252, 0.7);
   --type-ui: 'VT323', monospace;
   --type-ui-sm: 'VT323', monospace;
   --type-label: 'VT323', monospace;
@@ -43,15 +43,15 @@ body {
 [data-theme="retro-blue"] .noc-header,
 [data-theme="retro-blue"] .noc-status-bar,
 [data-theme="retro-blue"] .console-output {
-  box-shadow: 0 0 20px rgba(0, 255, 255, 0.35), inset 0 0 10px rgba(255, 0, 255, 0.15);
-  border-color: #00ffff !important;
+  box-shadow: 0 0 20px rgba(51, 204, 255, 0.25), inset 0 0 10px rgba(56, 189, 248, 0.1);
+  border-color: #33ccff !important;
 }
 
 [data-theme="retro-blue"] button:hover {
-  background: rgba(0, 255, 255, 0.25) !important;
-  color: #ff00ff !important;
-  border-color: #ff00ff !important;
-  box-shadow: 0 0 12px rgba(255, 0, 255, 0.6);
+  background: rgba(251, 191, 36, 0.2) !important;
+  color: #fbbf24 !important;
+  border-color: #fbbf24 !important;
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.5);
 }
 
 /* Critical UI Component Styles */

--- a/frontend/src/stores/themeStore.ts
+++ b/frontend/src/stores/themeStore.ts
@@ -52,21 +52,24 @@ const classic: Theme = {
 const retroBlue: Theme = {
   key: 'retro-blue',
   label: 'Retro Blue',
-  primary: '#00ffff',
-  primaryRgb: '0, 255, 255',
-  background: '#040814',
-  nodeHueMin: 0,
-  nodeHueMax: 360,
-  nodeSat: 100,
-  nodeLightMin: 55,
-  nodeLightMax: 85,
-  edgeTcp: '#00ffff',
-  edgeUdp: '#ff00ff',
-  edgeIcmp: '#ff0055',
-  edgeHttp: '#00ff66',
-  edgeDefault: '#ffff00',
-  groupHalo: '#ff00aa',
-  labelColor: '#00ffff',
+  primary: '#33ccff',
+  primaryRgb: '51, 204, 255',
+  background: '#04101f',       // deep navy
+  // subnet hues live in the cyan → blue → violet band so blobs read as groups
+  nodeHueMin: 185,
+  nodeHueMax: 265,
+  nodeSat: 88,
+  nodeLightMin: 45,
+  nodeLightMax: 68,
+  // edges keep protocol meaning but shift into the blue field's complement set;
+  // amber/magenta stay as high-contrast accents that pop against navy
+  edgeTcp: '#38bdf8',
+  edgeUdp: '#c084fc',
+  edgeIcmp: '#fbbf24',
+  edgeHttp: '#f472b6',
+  edgeDefault: '#22d3ee',
+  groupHalo: '#fbbf24',
+  labelColor: '#7dd3fc',
 }
 
 const blackhatNoc: Theme = {


### PR DESCRIPTION
### Description
This pull request refines the Retro Blue theme to restore its original curated color palette prior to UIKit integration while ensuring full-theme UI chrome overrides remain active.

### Key Changes
1. **Original Retro Blue Color Palette Restored**:
   - Replaced temporary full-spectrum neon test values in `themeStore.ts` with the original curated palette (`#33ccff` primary, `#04101f` deep navy background, `185-265` degree cyan/blue/violet subnet hue band).
   - Restored original protocol edge colors: `#38bdf8` (TCP), `#c084fc` (UDP), `#f472b6` (HTTP), `#fbbf24` (ICMP/Halo), `#22d3ee` (Default).
2. **Harmonized UI Chrome Overrides**:
   - Updated `[data-theme="retro-blue"]`, `.settings-panel`, `.noc-header`, `.noc-status-bar`, and `.console-output` CSS rules in `index.css` to use `#33ccff` borders, deep navy chrome backgrounds, and amber (`#fbbf24`) hover highlights.
   - Ensures that when Retro Blue is selected, all UI elements reflect the retro blue palette while disregarding default UIKit green tokens.