### PR TITLE
feat: consolidate console UI responsiveness, badge standardization, and window slash commands

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import './index.css'
 import { logger } from './utils/logger'
 import { useWebSocketPinning } from './hooks/useWebSocketPinning'
 import { useThemeStore } from './stores/themeStore'
+import { useWindowStore } from './stores/windowStore'
 
 // Import critical components directly 
 import { RendererSelector } from './components/RendererSelector'
@@ -52,10 +53,14 @@ export const App = memo(() => {
   const [currentRoute, setCurrentRoute] = useState(window.location.hash.slice(1) || 'main');
   const [initialLoad, setInitialLoad] = useState(true);
   const [performanceTestData, setPerformanceTestData] = useState({ enabled: false, nodeCount: 0, connectionCount: 0 });
-  const [showSettings, setShowSettings] = useState(captureMode === 'waiting');
-  const [showDebug, setShowDebug] = useState(false);
-  const [showLegend, setShowLegend] = useState(true);
+  const { showSettings, showDebug, showLegend, toggleSettings, toggleDebug, toggleLegend } = useWindowStore();
   const [showPerfTest, setShowPerfTest] = useState(false);
+
+  useEffect(() => {
+    if (captureMode === 'waiting') {
+      toggleSettings(true);
+    }
+  }, [captureMode, toggleSettings]);
 
   // --- Store Hooks ---
   const { packets, clearPackets } = usePacketStore()
@@ -455,11 +460,11 @@ export const App = memo(() => {
           error={error}
           captureMode={captureMode}
           showSettings={showSettings}
-          onToggleSettings={() => setShowSettings(!showSettings)}
+          onToggleSettings={() => toggleSettings()}
           showDebug={showDebug}
-          onToggleDebug={() => setShowDebug(!showDebug)}
+          onToggleDebug={() => toggleDebug()}
           showLegend={showLegend}
-          onToggleLegend={() => setShowLegend(!showLegend)}
+          onToggleLegend={() => toggleLegend()}
         />
         
         {/* Conditionally render content based on route */}
@@ -484,7 +489,7 @@ export const App = memo(() => {
                 zeekTcpAddr={zeekTcpAddr}
                 onZeekTcpAddrChange={setZeekTcpAddr}
                 wsPreviewUrl={wsUrl}
-                onMinimize={() => setShowSettings(false)}
+                onMinimize={() => toggleSettings(false)}
               />
             </div>
           </div>
@@ -500,7 +505,7 @@ export const App = memo(() => {
         {/* Unified Debug Panel */}
         <UnifiedDebugPanel 
           isOpen={showDebug}
-          onMinimize={() => setShowDebug(false)}
+          onMinimize={() => toggleDebug(false)}
           onTestModeChange={handleTestModeChange}
           onRendererChange={handleRendererChange}
           currentRenderer={currentRenderer}
@@ -521,7 +526,7 @@ export const App = memo(() => {
             }
           ]}
         />
-        <ThemeLegend isOpen={showLegend} onMinimize={() => setShowLegend(false)} />
+        <ThemeLegend isOpen={showLegend} onMinimize={() => toggleLegend(false)} />
         
         <NocStatusBar status={status} error={error} />
       </CaptureContext.Provider>

--- a/frontend/src/components/CommandBar.tsx
+++ b/frontend/src/components/CommandBar.tsx
@@ -196,7 +196,7 @@ export const CommandBar: React.FC<CommandBarProps> = ({ onConsoleToggle }) => {
             highlight={code => Prism.highlight(code, Prism.languages.vibes, 'vibes')}
             padding={{ top: 8, right: 10, bottom: 8, left: 2 }}
             className="command-input-editor"
-            placeholder={showConsole ? "Enter command... (/help)" : "CONSOLE ['~' to toggle] | /help"}
+            placeholder={showConsole ? "command (/help)" : "CONSOLE (~ or /help)"}
           />
         </div>
       </div>

--- a/frontend/src/components/CommandBar.tsx
+++ b/frontend/src/components/CommandBar.tsx
@@ -3,11 +3,12 @@ import Editor from 'react-simple-code-editor';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism-tomorrow.css';
 import { usePinStore } from '../stores/pinStore';
+import { useWindowStore } from '../stores/windowStore';
 
 // --- Custom PrismJS Grammar for our commands ---
 Prism.languages.vibes = {
   'command': {
-    pattern: /^\/(pin|unpin|pinned|list|help|whoami)\b/,
+    pattern: /^\/(pin|unpin|pinned|list|debug|legend|settings|help|whoami)\b/,
     alias: 'keyword',
   },
   'subcommand': {
@@ -46,6 +47,7 @@ export const CommandBar: React.FC<CommandBarProps> = ({ onConsoleToggle }) => {
   const [history, setHistory] = useState<string[]>([]);
   const [showConsole, setShowConsole] = useState(false);
   const { addPinningRule, removePinningRule, pinningRules, clearAllPins } = usePinStore();
+  const { toggleSettings, toggleDebug, toggleLegend } = useWindowStore();
   const containerRef = useRef<HTMLDivElement>(null);
   const consoleOutputRef = useRef<HTMLDivElement>(null);
 
@@ -75,8 +77,41 @@ export const CommandBar: React.FC<CommandBarProps> = ({ onConsoleToggle }) => {
       }
     } else if (action === '/pinned' || (action === '/list' && arg0 === 'pinned')) {
       output = `Active pinning rules: ${Array.from(pinningRules).join(', ')}`;
+    } else if (action === '/debug') {
+      if (arg0 === 'open' || arg0 === 'on' || arg0 === '1') {
+        toggleDebug(true);
+        output = 'Debug window opened.';
+      } else if (arg0 === 'close' || arg0 === 'off' || arg0 === '0') {
+        toggleDebug(false);
+        output = 'Debug window closed.';
+      } else {
+        toggleDebug();
+        output = 'Toggled debug window.';
+      }
+    } else if (action === '/legend') {
+      if (arg0 === 'open' || arg0 === 'on' || arg0 === '1') {
+        toggleLegend(true);
+        output = 'Legend window opened.';
+      } else if (arg0 === 'close' || arg0 === 'off' || arg0 === '0') {
+        toggleLegend(false);
+        output = 'Legend window closed.';
+      } else {
+        toggleLegend();
+        output = 'Toggled legend window.';
+      }
+    } else if (action === '/settings') {
+      if (arg0 === 'open' || arg0 === 'on' || arg0 === '1') {
+        toggleSettings(true);
+        output = 'Settings panel opened.';
+      } else if (arg0 === 'close' || arg0 === 'off' || arg0 === '0') {
+        toggleSettings(false);
+        output = 'Settings panel closed.';
+      } else {
+        toggleSettings();
+        output = 'Toggled settings panel.';
+      }
     } else if (action === '/help') {
-      output = `Available commands: /pin, /unpin, /pinned, /list pinned, /help, /whoami`;
+      output = `Available commands: /pin, /unpin, /pinned, /list pinned, /debug, /legend, /settings, /help, /whoami`;
     } else if (action === '/whoami') {
       output = 'd4rkm4tter was here';
     } else {

--- a/frontend/src/components/CommandBar.tsx
+++ b/frontend/src/components/CommandBar.tsx
@@ -196,7 +196,7 @@ export const CommandBar: React.FC<CommandBarProps> = ({ onConsoleToggle }) => {
             highlight={code => Prism.highlight(code, Prism.languages.vibes, 'vibes')}
             padding={{ top: 8, right: 10, bottom: 8, left: 2 }}
             className="command-input-editor"
-            placeholder="CONSOLE ['~' to toggle] | /help"
+            placeholder={showConsole ? "Enter command... (/help)" : "CONSOLE ['~' to toggle] | /help"}
           />
         </div>
       </div>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -329,9 +329,7 @@ export const SettingsPanel: React.FC<{
         )}
 
         {activeTab === 'physics' && (
-          <div style={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto', paddingRight: '8px' }}>
-            <PhysicsPanel />
-          </div>
+          <PhysicsPanel />
         )}
       </div>
     </div>

--- a/frontend/src/components/noc/NocHeader.tsx
+++ b/frontend/src/components/noc/NocHeader.tsx
@@ -74,7 +74,7 @@ export const NocHeader: React.FC<NocHeaderProps> = ({
       }}
     >
       {/* Wordmark and Identity */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', minWidth: 0, flexShrink: 1 }}>
         <span
           style={{
             font: 'var(--type-label)',
@@ -82,17 +82,23 @@ export const NocHeader: React.FC<NocHeaderProps> = ({
             textTransform: 'uppercase',
             color: 'var(--text-hi, #fff)',
             fontWeight: 700,
+            flexShrink: 0,
           }}
         >
           VIBES
         </span>
-        <div style={{ width: '1px', height: '24px', background: 'var(--line-strong, rgba(255,255,255,0.2))' }} />
+        <div style={{ width: '1px', height: '24px', background: 'var(--line-strong, rgba(255,255,255,0.2))', flexShrink: 0 }} />
         <span
+          className="noc-header-subtitle"
           style={{
             font: 'var(--type-label)',
             letterSpacing: 'var(--tracking-wide, 0.14em)',
             textTransform: 'uppercase',
             color: 'var(--text-faint, rgba(255,255,255,0.6))',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            minWidth: 0,
           }}
         >
           Network Operations Center

--- a/frontend/src/components/noc/NocHeader.tsx
+++ b/frontend/src/components/noc/NocHeader.tsx
@@ -251,41 +251,12 @@ export const NocHeader: React.FC<NocHeaderProps> = ({
           <span>Settings</span>
         </button>
 
-        {/* Connection status dot */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '5px 12px',
-            border: `1px solid ${status === 'connected' ? 'var(--signal-teal)' : status === 'connecting' ? 'var(--signal-amber)' : 'var(--signal-red)'}`,
-            borderRadius: '999px',
-            background: status === 'connected' ? 'var(--wash-ok)' : status === 'connecting' ? 'var(--wash-medium)' : 'var(--wash-critical)',
-          }}
-          title={error || undefined}
-        >
-          <StatusDot
-            status={
-              status === 'connected'
-                ? 'ok'
-                : status === 'connecting'
-                ? 'warning'
-                : 'critical'
-            }
-            size={7}
-            pulse={status === 'connected'}
-          />
-          <span
-            style={{
-              font: 'var(--type-data-sm)',
-              color: status === 'connected' ? 'var(--signal-teal)' : status === 'connecting' ? 'var(--signal-amber)' : 'var(--signal-red)',
-              textTransform: 'uppercase',
-              letterSpacing: 'var(--tracking-label, 0.08em)',
-            }}
-          >
-            {status}
-          </span>
-        </div>
+        {/* Connection status badge */}
+        <SeverityBadge
+          level={status === 'connected' ? 'ok' : status === 'connecting' ? 'medium' : 'critical'}
+          label={status}
+          showDot={true}
+        />
 
         {/* Local/UTC timestamp in monospace tabular numerals */}
         <span

--- a/frontend/src/components/noc/NocStatusBar.tsx
+++ b/frontend/src/components/noc/NocStatusBar.tsx
@@ -44,7 +44,10 @@ export const NocStatusBar = memo(({ error }: NocStatusBarProps) => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
-        padding: '0 18px',
+        flexWrap: 'nowrap',
+        overflowX: 'auto',
+        gap: '12px',
+        padding: '0 14px',
         background: 'var(--surface-chrome, #0e0e0e)',
         borderTop: 'var(--border-inset, 1px solid rgba(255, 255, 255, 0.1))',
         borderBottom: isConsoleOpen ? 'none' : undefined,
@@ -53,7 +56,7 @@ export const NocStatusBar = memo(({ error }: NocStatusBarProps) => {
       }}
     >
       {/* Left side: Command bar console trigger */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flex: '1 1 360px', minWidth: '260px', maxWidth: '480px', marginRight: '20px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flex: '1 1 auto', minWidth: '140px', maxWidth: '360px' }}>
         <CommandBar onConsoleToggle={setIsConsoleOpen} />
       </div>
 
@@ -62,14 +65,16 @@ export const NocStatusBar = memo(({ error }: NocStatusBarProps) => {
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: '20px',
-          fontSize: '12px',
+          gap: '14px',
+          fontSize: '11px',
           fontFamily: 'var(--font-mono)',
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
         }}
       >
         <SeverityBadge level={sourceInfo.level} label={sourceInfo.label} />
 
-        <span style={{ display: 'flex', alignItems: 'baseline', gap: '6px', color: 'var(--text-muted)' }}>
+        <span style={{ display: 'flex', alignItems: 'baseline', gap: '5px', color: 'var(--text-muted)' }}>
           PACKETS:
           <strong
             style={{
@@ -83,7 +88,7 @@ export const NocStatusBar = memo(({ error }: NocStatusBarProps) => {
           </strong>
         </span>
 
-        <span style={{ display: 'flex', alignItems: 'baseline', gap: '6px', color: 'var(--text-muted)' }}>
+        <span style={{ display: 'flex', alignItems: 'baseline', gap: '5px', color: 'var(--text-muted)' }}>
           NODES:
           <strong
             style={{
@@ -97,7 +102,7 @@ export const NocStatusBar = memo(({ error }: NocStatusBarProps) => {
           </strong>
         </span>
 
-        <span style={{ display: 'flex', alignItems: 'baseline', gap: '6px', color: 'var(--text-muted)' }}>
+        <span style={{ display: 'flex', alignItems: 'baseline', gap: '5px', color: 'var(--text-muted)' }}>
           CONNECTIONS:
           <strong
             style={{

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,11 +102,16 @@ body {
   background: rgba(0, 0, 0, 0.35);
 }
 .settings-panel .tab-content::-webkit-scrollbar-thumb {
-  background: rgba(var(--vibes-primary-rgb, 0, 255, 0), 0.45);
+  background: var(--signal-teal, var(--vibes-primary, #33ccff));
   border-radius: 4px;
 }
 .settings-panel .tab-content::-webkit-scrollbar-thumb:hover {
-  background: rgba(var(--vibes-primary-rgb, 0, 255, 0), 0.75);
+  background: var(--signal-teal, var(--vibes-primary, #33ccff));
+  filter: brightness(1.2);
+}
+
+input[type="range"] {
+  accent-color: var(--signal-teal, var(--vibes-primary, #33ccff));
 }
 
 .settings-panel h2 {
@@ -364,12 +369,13 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-primary);
-  border-radius: 0;
+  background: var(--signal-teal, var(--vibes-primary, #33ccff));
+  border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-secondary);
+  background: var(--signal-teal, var(--vibes-primary, #33ccff));
+  filter: brightness(1.2);
 }
 
 /* Animation keyframes */
@@ -533,5 +539,14 @@ body {
 @media (max-width: 860px) {
   .noc-header-subtitle {
     display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .command-input-editor textarea::placeholder,
+  .command-input-editor input::placeholder,
+  .command-input-editor::placeholder {
+    color: transparent !important;
+    opacity: 0 !important;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -523,5 +523,15 @@ body {
   color: #ff0000; /* Red for operators like '/' and '-' */
 }
 
+/* --- Responsive NOC Header & Footer --- */
+@media (max-width: 1024px) {
+  .noc-header-subtitle {
+    max-width: 140px;
+  }
+}
 
- 
+@media (max-width: 860px) {
+  .noc-header-subtitle {
+    display: none;
+  }
+}

--- a/frontend/src/stores/windowStore.ts
+++ b/frontend/src/stores/windowStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+export interface WindowState {
+  showSettings: boolean;
+  showDebug: boolean;
+  showLegend: boolean;
+  toggleSettings: (force?: boolean) => void;
+  toggleDebug: (force?: boolean) => void;
+  toggleLegend: (force?: boolean) => void;
+}
+
+export const useWindowStore = create<WindowState>((set) => ({
+  showSettings: false,
+  showDebug: false,
+  showLegend: true,
+  toggleSettings: (force) =>
+    set((state) => ({
+      showSettings: force !== undefined ? force : !state.showSettings,
+    })),
+  toggleDebug: (force) =>
+    set((state) => ({
+      showDebug: force !== undefined ? force : !state.showDebug,
+    })),
+  toggleLegend: (force) =>
+    set((state) => ({
+      showLegend: force !== undefined ? force : !state.showLegend,
+    })),
+}));


### PR DESCRIPTION
### Description
This pull request consolidates four sequential feature branches into a single update delivering responsive header/footer layouts, badge shape standardization, window management slash commands, and scrollbar/placeholder visual refinements.

### Key Enhancements & Refinements
1. **Responsive NOC Header & Footer Without Overflow**:
   - Updated `NocHeader.tsx` with flexible title container sizing (`minWidth: 0`, `flexShrink: 1`) and truncation on the subtitle (`whiteSpace: nowrap`, `overflow: hidden`, `textOverflow: ellipsis`).
   - Added media queries in `index.css` to hide the subtitle on screens narrower than `860px`.
   - Optimized `NocStatusBar.tsx` with `flexWrap: nowrap`, `overflowX: auto`, and responsive gap constraints so telemetry counters and the status chip never overflow.
2. **Standardized Rounded Rectangle Status Badges**:
   - Replaced custom pill-shaped connection badges in `NocHeader.tsx` with standard `<SeverityBadge />` rounded rectangles (`borderRadius: 'var(--radius-md, 8px)'`).
   - All connection status badges (`connected`, `connecting`, `error`, etc.) now match the exact rounded-rectangle styling used by simulated traffic and capture indicators.
3. **Zustand Window Store & `/debug`, `/legend`, `/settings` Slash Commands**:
   - Created `windowStore.ts` in Zustand to manage floating window visibility (`showSettings`, `showDebug`, `showLegend`) globally across components.
   - Implemented `/debug`, `/legend`, and `/settings` slash commands in `CommandBar.tsx`, allowing operators to toggle windows or pass explicit arguments (`/debug open`, `/legend close`, `/settings on`).
   - Updated syntax highlighting in Prism and listed commands in `/help` output.
4. **Scrollbar & Slider Color Harmonization**:
   - Styled all scrollbar thumbs (`::-webkit-scrollbar-thumb`) and slider controls (`input[type="range"]`) to use `var(--signal-teal, var(--vibes-primary, #33ccff))`, ensuring scrollbars match slider bars across themes.
   - Removed redundant scrollable wrapper on the Physics menu in `SettingsPanel.tsx`, eliminating duplicate scrollbars.
5. **Responsive Console Placeholder**:
   - Updated `CommandBar.tsx` placeholders to concise text (`"command (/help)"` when open and `"CONSOLE (~ or /help)"` when closed) to prevent line wrapping.
   - Added a responsive media query (`max-width: 900px`) in `index.css` to hide placeholder text when the window is compressed to <= 50% width.