### PR TITLE
feat: add NetFlow v9 UDP collector as alternate capture source

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -280,6 +280,9 @@ func (manager *ClientManager) HandleWebSocket(w http.ResponseWriter, r *http.Req
 		}
 	}
 
+	netflowParam := r.URL.Query().Get("netflow")
+	wantNetflow := netflowParam == "1" || netflowParam == "true" || strings.EqualFold(netflowParam, "v9")
+
 	if selectedPcapFile != "" {
 		config := capture.PCAPReplayConfig{
 			FilePath:    selectedPcapFile,
@@ -290,6 +293,9 @@ func (manager *ClientManager) HandleWebSocket(w http.ResponseWriter, r *http.Req
 	} else if zeekAddr != "" {
 		captureSystem = capture.NewZeekConnJSONCapture(zeekAddr)
 		captureMode = "zeek_conn"
+	} else if wantNetflow {
+		captureSystem = capture.NewNetFlowV9Capture()
+		captureMode = "netflow_v9"
 	} else if *useDumpcap {
 		captureSystem = capture.NewDumpcapTailer(*dumpcapDir)
 		captureMode = "dumpcap"
@@ -337,6 +343,9 @@ func (manager *ClientManager) HandleWebSocket(w http.ResponseWriter, r *http.Req
 			log.Printf("*** 🔥 PCAP REPLAY ACTIVE: %s (%.2fx speed) ***", selectedPcapFile, selectedReplaySpeed)
 		case "zeek_conn":
 			log.Printf("*** 🦅 ZEEK CONN JSON (TCP) ACTIVE: ingest %s ***", zeekAddr)
+		case "netflow_v9":
+			st := capture.GetNetFlowManager().Status()
+			log.Printf("*** 🌊 NETFLOW V9 ACTIVE (listener %s on %s) ***", st.State, st.ListenAddr)
 		case "simulated":
 			log.Printf("*** 🎮 SIMULATION ACTIVE (synthetic traffic) ***")
 		}
@@ -360,6 +369,7 @@ func (manager *ClientManager) HandleWebSocket(w http.ResponseWriter, r *http.Req
 
 	// Send mode information to the client
 	var modeMessage []byte
+	nfStatus := capture.GetNetFlowManager().Status()
 	if captureFailed {
 		// Send error message with fallback info
 		modeMessage, _ = json.Marshal(map[string]interface{}{
@@ -369,6 +379,7 @@ func (manager *ClientManager) HandleWebSocket(w http.ResponseWriter, r *http.Req
 			"pcapFile": selectedPcapFile,
 			"replaySpeed": selectedReplaySpeed,
 			"zeek_tcp": zeekAddr,
+			"netflow": nfStatus,
 			"error": true,
 			"errorMsg": captureErrorMsg,
 			"requestedMode": originalMode,
@@ -382,6 +393,7 @@ func (manager *ClientManager) HandleWebSocket(w http.ResponseWriter, r *http.Req
 			"pcapFile": selectedPcapFile,
 			"replaySpeed": selectedReplaySpeed,
 			"zeek_tcp": zeekAddr,
+			"netflow": nfStatus,
 		})
 	}
 	client.send <- modeMessage
@@ -823,6 +835,90 @@ func main() {
 		json.NewEncoder(w).Encode(interfaces)
 	})
 
+	writeCORS := func(w http.ResponseWriter) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+
+	http.HandleFunc("/api/netflow/addresses", func(w http.ResponseWriter, r *http.Request) {
+		writeCORS(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		addrs, err := capture.ListHostAddresses()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(addrs)
+	})
+
+	http.HandleFunc("/api/netflow/status", func(w http.ResponseWriter, r *http.Request) {
+		writeCORS(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		json.NewEncoder(w).Encode(capture.GetNetFlowManager().Status())
+	})
+
+	http.HandleFunc("/api/netflow/start", func(w http.ResponseWriter, r *http.Request) {
+		writeCORS(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req struct {
+			IP   string `json:"ip"`
+			Port int    `json:"port"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body (need ip, port)", http.StatusBadRequest)
+			return
+		}
+		if req.Port == 0 {
+			req.Port = 2055
+		}
+		if err := capture.GetNetFlowManager().Start(req.IP, req.Port); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":  err.Error(),
+				"status": capture.GetNetFlowManager().Status(),
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(capture.GetNetFlowManager().Status())
+	})
+
+	http.HandleFunc("/api/netflow/stop", func(w http.ResponseWriter, r *http.Request) {
+		writeCORS(w)
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		_ = capture.GetNetFlowManager().Stop()
+		json.NewEncoder(w).Encode(capture.GetNetFlowManager().Status())
+	})
+
 	http.HandleFunc("/api/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		dumpcapStatus := map[string]interface{}{
@@ -838,6 +934,7 @@ func main() {
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"dumpcap": dumpcapStatus,
+			"netflow": capture.GetNetFlowManager().Status(),
 		})
 	})
 
@@ -889,6 +986,8 @@ func main() {
 		manager.timeWindowProcessor.Stop()
 	}
 	manager.stateMutex.Unlock()
+
+	_ = capture.GetNetFlowManager().Stop()
 
 	log.Println("Server exited cleanly")
 }

--- a/backend/internal/capture/netflow_manager.go
+++ b/backend/internal/capture/netflow_manager.go
@@ -1,0 +1,362 @@
+package capture
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// NetFlowListenerStatus is the public listener state for the UI / API.
+type NetFlowListenerStatus struct {
+	State         string `json:"state"` // "stopped" | "listening" | "error"
+	BindIP        string `json:"bind_ip"`
+	Port          int    `json:"port"`
+	ListenAddr    string `json:"listen_addr"`
+	Templates     int    `json:"templates"`
+	DatagramsOK   uint64 `json:"datagrams_ok"`
+	DatagramsBad  uint64 `json:"datagrams_bad"`
+	FlowsOK       uint64 `json:"flows_ok"`
+	LastError     string `json:"last_error,omitempty"`
+	LastPacketAt  string `json:"last_packet_at,omitempty"`
+	SubscriberCnt int    `json:"subscribers"`
+}
+
+// HostAddress is a bindable IPv4/IPv6 address on this machine.
+type HostAddress struct {
+	IP        string `json:"ip"`
+	Interface string `json:"interface"`
+	Family    string `json:"family"` // "ipv4" | "ipv6"
+}
+
+// NetFlowManager is a process-wide NetFlow v9 UDP collector with Start/Stop control.
+type NetFlowManager struct {
+	mu         sync.Mutex
+	pc         net.PacketConn
+	bindIP     string
+	port       int
+	state      string // stopped | listening | error
+	lastError  string
+	lastPacket time.Time
+	decoder    *netflowDecoder
+	subs       map[chan *Packet]struct{}
+	stopCh     chan struct{}
+	readDone   chan struct{}
+
+	datagramsOK  atomic.Uint64
+	datagramsBad atomic.Uint64
+	flowsOK      atomic.Uint64
+}
+
+var globalNetFlow = &NetFlowManager{
+	state:   "stopped",
+	decoder: newNetflowDecoder(),
+	subs:    make(map[chan *Packet]struct{}),
+}
+
+// GetNetFlowManager returns the process-wide NetFlow collector.
+func GetNetFlowManager() *NetFlowManager {
+	return globalNetFlow
+}
+
+// ListHostAddresses returns non-loopback and loopback IPs available for binding,
+// plus the wildcard 0.0.0.0 entry for "all interfaces".
+func ListHostAddresses() ([]HostAddress, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	out := []HostAddress{{
+		IP:        "0.0.0.0",
+		Interface: "*",
+		Family:    "ipv4",
+	}}
+
+	seen := map[string]bool{"0.0.0.0": true}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil {
+				continue
+			}
+			// Prefer IPv4 for NetFlow exporters; skip link-local IPv6 noise.
+			if ip4 := ip.To4(); ip4 != nil {
+				s := ip4.String()
+				if seen[s] {
+					continue
+				}
+				seen[s] = true
+				out = append(out, HostAddress{IP: s, Interface: iface.Name, Family: "ipv4"})
+			}
+		}
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		// Keep 0.0.0.0 first, then non-loopback, then loopback.
+		rank := func(a HostAddress) int {
+			if a.IP == "0.0.0.0" {
+				return 0
+			}
+			if a.IP == "127.0.0.1" {
+				return 2
+			}
+			return 1
+		}
+		ri, rj := rank(out[i]), rank(out[j])
+		if ri != rj {
+			return ri < rj
+		}
+		return out[i].IP < out[j].IP
+	})
+	return out, nil
+}
+
+// Status returns a snapshot of the listener.
+func (m *NetFlowManager) Status() NetFlowListenerStatus {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := NetFlowListenerStatus{
+		State:         m.state,
+		BindIP:        m.bindIP,
+		Port:          m.port,
+		Templates:     m.decoder.templateCount(),
+		DatagramsOK:   m.datagramsOK.Load(),
+		DatagramsBad:  m.datagramsBad.Load(),
+		FlowsOK:       m.flowsOK.Load(),
+		LastError:     m.lastError,
+		SubscriberCnt: len(m.subs),
+	}
+	if m.bindIP != "" && m.port > 0 {
+		st.ListenAddr = fmt.Sprintf("%s:%d", m.bindIP, m.port)
+	}
+	if !m.lastPacket.IsZero() {
+		st.LastPacketAt = m.lastPacket.UTC().Format(time.RFC3339)
+	}
+	return st
+}
+
+// Start binds a UDP NetFlow v9 listener on bindIP:port.
+// bindIP may be "0.0.0.0" for all interfaces. Port must be 1024–65535.
+func (m *NetFlowManager) Start(bindIP string, port int) error {
+	if bindIP == "" {
+		bindIP = "0.0.0.0"
+	}
+	if port < 1024 || port > 65535 {
+		return fmt.Errorf("port must be between 1024 and 65535")
+	}
+	ip := net.ParseIP(bindIP)
+	if ip == nil {
+		return fmt.Errorf("invalid bind IP %q", bindIP)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.pc != nil {
+		return fmt.Errorf("netflow listener already running on %s:%d — stop it first", m.bindIP, m.port)
+	}
+
+	addr := &net.UDPAddr{IP: ip, Port: port}
+	pc, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		m.state = "error"
+		m.lastError = err.Error()
+		return fmt.Errorf("listen udp %s: %w", addr.String(), err)
+	}
+	_ = pc.SetReadBuffer(4 * 1024 * 1024)
+
+	m.pc = pc
+	m.bindIP = bindIP
+	m.port = port
+	m.state = "listening"
+	m.lastError = ""
+	m.stopCh = make(chan struct{})
+	m.readDone = make(chan struct{})
+
+	go m.readLoop(pc, m.stopCh, m.readDone)
+	log.Printf("🌊 NetFlow v9 UDP listening on %s (point exporters here)", addr.String())
+	return nil
+}
+
+// Stop closes the UDP listener. Subscribers stay attached so WS clients can wait for a restart.
+func (m *NetFlowManager) Stop() error {
+	m.mu.Lock()
+	pc := m.pc
+	stopCh := m.stopCh
+	readDone := m.readDone
+	m.pc = nil
+	m.state = "stopped"
+	m.stopCh = nil
+	m.readDone = nil
+	m.mu.Unlock()
+
+	if pc == nil {
+		return nil
+	}
+	if stopCh != nil {
+		close(stopCh)
+	}
+	_ = pc.Close()
+	if readDone != nil {
+		<-readDone
+	}
+	log.Printf("🌊 NetFlow v9 UDP listener stopped")
+	return nil
+}
+
+func (m *NetFlowManager) readLoop(pc net.PacketConn, stopCh <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	buf := make([]byte, 65535)
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		_ = pc.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, addr, err := pc.ReadFrom(buf)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			m.mu.Lock()
+			if m.pc == pc {
+				m.state = "error"
+				m.lastError = err.Error()
+			}
+			m.mu.Unlock()
+			log.Printf("netflow read error: %v", err)
+			return
+		}
+		if n == 0 {
+			continue
+		}
+
+		var exporter net.IP
+		if ua, ok := addr.(*net.UDPAddr); ok {
+			exporter = ua.IP
+		} else {
+			exporter = net.IPv4zero
+		}
+
+		pkts, err := m.decoder.decodePacket(exporter, buf[:n])
+		if err != nil {
+			bad := m.datagramsBad.Add(1)
+			if bad == 1 || bad%1000 == 0 {
+				log.Printf("netflow: decode failures=%d last=%v from %s", bad, err, addr)
+			}
+			continue
+		}
+		m.datagramsOK.Add(1)
+		m.mu.Lock()
+		m.lastPacket = time.Now()
+		m.mu.Unlock()
+
+		for _, p := range pkts {
+			m.flowsOK.Add(1)
+			m.broadcast(p)
+		}
+	}
+}
+
+func (m *NetFlowManager) broadcast(p *Packet) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for ch := range m.subs {
+		select {
+		case ch <- p:
+		default:
+			// Drop if subscriber is slow — never block the UDP reader.
+		}
+	}
+}
+
+func (m *NetFlowManager) subscribe(ch chan *Packet) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.subs == nil {
+		m.subs = make(map[chan *Packet]struct{})
+	}
+	m.subs[ch] = struct{}{}
+}
+
+func (m *NetFlowManager) unsubscribe(ch chan *Packet) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.subs, ch)
+}
+
+// IsListening reports whether the UDP socket is currently bound.
+func (m *NetFlowManager) IsListening() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pc != nil && m.state == "listening"
+}
+
+// --- PacketCapture adapter (one per WebSocket client) ---
+
+// NetFlowV9Capture fans in packets from the process-wide NetFlowManager.
+type NetFlowV9Capture struct {
+	packetChan chan *Packet
+	running    bool
+	mu         sync.Mutex
+}
+
+// NewNetFlowV9Capture creates a subscriber capture for NetFlow v9 mode.
+func NewNetFlowV9Capture() *NetFlowV9Capture {
+	return &NetFlowV9Capture{
+		packetChan: make(chan *Packet, 8192),
+	}
+}
+
+func (n *NetFlowV9Capture) Start() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.running {
+		return fmt.Errorf("netflow capture already running")
+	}
+	GetNetFlowManager().subscribe(n.packetChan)
+	n.running = true
+	st := GetNetFlowManager().Status()
+	if st.State != "listening" {
+		log.Printf("🌊 NetFlow capture subscribed (listener is %s — start it from the UI)", st.State)
+	} else {
+		log.Printf("🌊 NetFlow capture subscribed to listener on %s", st.ListenAddr)
+	}
+	return nil
+}
+
+func (n *NetFlowV9Capture) Stop() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if !n.running {
+		return fmt.Errorf("netflow capture not running")
+	}
+	GetNetFlowManager().unsubscribe(n.packetChan)
+	n.running = false
+	return nil
+}
+
+func (n *NetFlowV9Capture) GetPacketChannel() <-chan *Packet {
+	return n.packetChan
+}

--- a/backend/internal/capture/netflow_v9.go
+++ b/backend/internal/capture/netflow_v9.go
@@ -1,0 +1,248 @@
+package capture
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+// NetFlow v9 field type IDs (RFC 3954 / Cisco common set).
+const (
+	nfIN_BYTES       uint16 = 1
+	nfIN_PKTS        uint16 = 2
+	nfPROTOCOL       uint16 = 4
+	nfL4_SRC_PORT    uint16 = 7
+	nfIPV4_SRC_ADDR  uint16 = 8
+	nfL4_DST_PORT    uint16 = 11
+	nfIPV4_DST_ADDR  uint16 = 12
+	nfLAST_SWITCHED  uint16 = 21
+	nfFIRST_SWITCHED uint16 = 22
+	nfOUT_BYTES      uint16 = 23
+	nfIPV6_SRC_ADDR  uint16 = 27
+	nfIPV6_DST_ADDR  uint16 = 28
+)
+
+type nfFieldDef struct {
+	Type   uint16
+	Length uint16
+}
+
+type nfTemplate struct {
+	ID     uint16
+	Fields []nfFieldDef
+}
+
+type nfTemplateKey struct {
+	Exporter string
+	SourceID uint32
+	ID       uint16
+}
+
+// netflowDecoder keeps per-exporter templates and turns NetFlow v9 UDP payloads into Packets.
+type netflowDecoder struct {
+	mu        sync.RWMutex
+	templates map[nfTemplateKey]*nfTemplate
+}
+
+func newNetflowDecoder() *netflowDecoder {
+	return &netflowDecoder{templates: make(map[nfTemplateKey]*nfTemplate)}
+}
+
+func (d *netflowDecoder) templateCount() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.templates)
+}
+
+// decodePacket parses one NetFlow v9 UDP datagram from exporter into zero or more Packets.
+func (d *netflowDecoder) decodePacket(exporter net.IP, payload []byte) ([]*Packet, error) {
+	if len(payload) < 20 {
+		return nil, fmt.Errorf("packet too short: %d", len(payload))
+	}
+	version := binary.BigEndian.Uint16(payload[0:2])
+	if version != 9 {
+		return nil, fmt.Errorf("unsupported netflow version %d", version)
+	}
+	count := binary.BigEndian.Uint16(payload[2:4])
+	unixSecs := binary.BigEndian.Uint32(payload[8:12])
+	sourceID := binary.BigEndian.Uint32(payload[16:20])
+	exporterKey := exporter.String()
+
+	offset := 20
+	var out []*Packet
+	setsSeen := 0
+
+	for offset+4 <= len(payload) && setsSeen < int(count)+64 {
+		setsSeen++
+		setID := binary.BigEndian.Uint16(payload[offset : offset+2])
+		setLen := int(binary.BigEndian.Uint16(payload[offset+2 : offset+4]))
+		if setLen < 4 || offset+setLen > len(payload) {
+			break
+		}
+		body := payload[offset+4 : offset+setLen]
+		offset += setLen
+
+		switch {
+		case setID == 0: // Template FlowSet
+			d.parseTemplates(exporterKey, sourceID, body)
+		case setID == 1: // Options Template FlowSet — ignore for viz
+			continue
+		case setID >= 256: // Data FlowSet
+			pkts := d.parseDataFlowSet(exporterKey, sourceID, setID, body, unixSecs)
+			out = append(out, pkts...)
+		default:
+			// Options data / reserved — skip
+		}
+	}
+	return out, nil
+}
+
+func (d *netflowDecoder) parseTemplates(exporter string, sourceID uint32, body []byte) {
+	pos := 0
+	for pos+4 <= len(body) {
+		templateID := binary.BigEndian.Uint16(body[pos : pos+2])
+		fieldCount := int(binary.BigEndian.Uint16(body[pos+2 : pos+4]))
+		pos += 4
+		need := fieldCount * 4
+		if pos+need > len(body) {
+			return
+		}
+		fields := make([]nfFieldDef, 0, fieldCount)
+		for i := 0; i < fieldCount; i++ {
+			fields = append(fields, nfFieldDef{
+				Type:   binary.BigEndian.Uint16(body[pos : pos+2]),
+				Length: binary.BigEndian.Uint16(body[pos+2 : pos+4]),
+			})
+			pos += 4
+		}
+		key := nfTemplateKey{Exporter: exporter, SourceID: sourceID, ID: templateID}
+		d.mu.Lock()
+		d.templates[key] = &nfTemplate{ID: templateID, Fields: fields}
+		d.mu.Unlock()
+	}
+}
+
+func (d *netflowDecoder) parseDataFlowSet(exporter string, sourceID uint32, templateID uint16, body []byte, unixSecs uint32) []*Packet {
+	key := nfTemplateKey{Exporter: exporter, SourceID: sourceID, ID: templateID}
+	d.mu.RLock()
+	tmpl := d.templates[key]
+	d.mu.RUnlock()
+	if tmpl == nil || len(tmpl.Fields) == 0 {
+		return nil
+	}
+
+	recordLen := 0
+	for _, f := range tmpl.Fields {
+		recordLen += int(f.Length)
+	}
+	if recordLen <= 0 {
+		return nil
+	}
+
+	var out []*Packet
+	pos := 0
+	for pos+recordLen <= len(body) {
+		rec := body[pos : pos+recordLen]
+		pos += recordLen
+		if p := packetFromNFRecord(tmpl.Fields, rec, unixSecs); p != nil {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func packetFromNFRecord(fields []nfFieldDef, rec []byte, unixSecs uint32) *Packet {
+	var (
+		src, dst       string
+		srcPort, dstPort int
+		size           int
+		protoNum       int = -1
+		haveSrc, haveDst bool
+	)
+
+	off := 0
+	for _, f := range fields {
+		if off+int(f.Length) > len(rec) {
+			return nil
+		}
+		val := rec[off : off+int(f.Length)]
+		off += int(f.Length)
+
+		switch f.Type {
+		case nfIPV4_SRC_ADDR:
+			if len(val) >= 4 {
+				src = net.IP(val[:4]).String()
+				haveSrc = true
+			}
+		case nfIPV4_DST_ADDR:
+			if len(val) >= 4 {
+				dst = net.IP(val[:4]).String()
+				haveDst = true
+			}
+		case nfIPV6_SRC_ADDR:
+			if len(val) >= 16 && !haveSrc {
+				src = net.IP(val[:16]).String()
+				haveSrc = true
+			}
+		case nfIPV6_DST_ADDR:
+			if len(val) >= 16 && !haveDst {
+				dst = net.IP(val[:16]).String()
+				haveDst = true
+			}
+		case nfL4_SRC_PORT:
+			srcPort = int(readUintBE(val))
+		case nfL4_DST_PORT:
+			dstPort = int(readUintBE(val))
+		case nfPROTOCOL:
+			protoNum = int(readUintBE(val))
+		case nfIN_BYTES, nfOUT_BYTES:
+			if n := int(readUintBE(val)); n > size {
+				size = n
+			}
+		}
+	}
+
+	if !haveSrc || !haveDst || src == "" || dst == "" {
+		return nil
+	}
+	if size <= 0 {
+		size = 1
+	}
+
+	proto := ProtocolOther
+	switch protoNum {
+	case 6:
+		proto = ProtocolTCP
+	case 17:
+		proto = ProtocolUDP
+	case 1, 58:
+		proto = ProtocolICMP
+	}
+
+	ts := time.Now().UnixMilli()
+	if unixSecs > 0 {
+		ts = int64(unixSecs) * 1000
+	}
+
+	return &Packet{
+		Type:      "packet",
+		Src:       src,
+		Dst:       dst,
+		SrcPort:   srcPort,
+		DstPort:   dstPort,
+		Size:      size,
+		Protocol:  proto,
+		Timestamp: ts,
+		Source:    "netflow",
+	}
+}
+
+func readUintBE(b []byte) uint64 {
+	var n uint64
+	for _, v := range b {
+		n = (n << 8) | uint64(v)
+	}
+	return n
+}

--- a/backend/internal/capture/netflow_v9_test.go
+++ b/backend/internal/capture/netflow_v9_test.go
@@ -1,0 +1,128 @@
+package capture
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+)
+
+func buildMinimalNF9Packet(t *testing.T, templateID uint16, src, dst net.IP, sport, dport uint16, proto byte, bytes uint32) []byte {
+	t.Helper()
+	// Template FlowSet: fields SRC, DST, SPORT, DPORT, PROTO, IN_BYTES
+	fields := []nfFieldDef{
+		{Type: nfIPV4_SRC_ADDR, Length: 4},
+		{Type: nfIPV4_DST_ADDR, Length: 4},
+		{Type: nfL4_SRC_PORT, Length: 2},
+		{Type: nfL4_DST_PORT, Length: 2},
+		{Type: nfPROTOCOL, Length: 1},
+		{Type: nfIN_BYTES, Length: 4},
+	}
+
+	tmplBody := make([]byte, 0, 4+len(fields)*4)
+	tb := make([]byte, 4)
+	binary.BigEndian.PutUint16(tb[0:2], templateID)
+	binary.BigEndian.PutUint16(tb[2:4], uint16(len(fields)))
+	tmplBody = append(tmplBody, tb...)
+	for _, f := range fields {
+		fb := make([]byte, 4)
+		binary.BigEndian.PutUint16(fb[0:2], f.Type)
+		binary.BigEndian.PutUint16(fb[2:4], f.Length)
+		tmplBody = append(tmplBody, fb...)
+	}
+	// Pad template set to 4-byte boundary
+	for len(tmplBody)%4 != 0 {
+		tmplBody = append(tmplBody, 0)
+	}
+
+	dataRec := make([]byte, 0, 17)
+	dataRec = append(dataRec, src.To4()...)
+	dataRec = append(dataRec, dst.To4()...)
+	pb := make([]byte, 2)
+	binary.BigEndian.PutUint16(pb, sport)
+	dataRec = append(dataRec, pb...)
+	binary.BigEndian.PutUint16(pb, dport)
+	dataRec = append(dataRec, pb...)
+	dataRec = append(dataRec, proto)
+	bb := make([]byte, 4)
+	binary.BigEndian.PutUint32(bb, bytes)
+	dataRec = append(dataRec, bb...)
+	for len(dataRec)%4 != 0 {
+		dataRec = append(dataRec, 0)
+	}
+
+	// Header (20) + tmpl set + data set
+	tmplSetLen := 4 + len(tmplBody)
+	dataSetLen := 4 + len(dataRec)
+	pkt := make([]byte, 20+tmplSetLen+dataSetLen)
+
+	binary.BigEndian.PutUint16(pkt[0:2], 9)          // version
+	binary.BigEndian.PutUint16(pkt[2:4], 2)          // count (flowsets)
+	binary.BigEndian.PutUint32(pkt[8:12], 1700000000) // unix secs
+	binary.BigEndian.PutUint32(pkt[16:20], 1)         // source id
+
+	off := 20
+	binary.BigEndian.PutUint16(pkt[off:off+2], 0) // template set
+	binary.BigEndian.PutUint16(pkt[off+2:off+4], uint16(tmplSetLen))
+	copy(pkt[off+4:], tmplBody)
+	off += tmplSetLen
+
+	binary.BigEndian.PutUint16(pkt[off:off+2], templateID)
+	binary.BigEndian.PutUint16(pkt[off+2:off+4], uint16(dataSetLen))
+	copy(pkt[off+4:], dataRec)
+
+	return pkt
+}
+
+func TestNetflowDecoder_BasicFlow(t *testing.T) {
+	d := newNetflowDecoder()
+	src := net.ParseIP("10.1.2.3")
+	dst := net.ParseIP("8.8.8.8")
+	pkt := buildMinimalNF9Packet(t, 256, src, dst, 54321, 443, 6, 1500)
+
+	out, err := d.decodePacket(net.ParseIP("192.168.1.1"), pkt)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 packet, got %d", len(out))
+	}
+	p := out[0]
+	if p.Src != "10.1.2.3" || p.Dst != "8.8.8.8" {
+		t.Fatalf("addrs: %s -> %s", p.Src, p.Dst)
+	}
+	if p.SrcPort != 54321 || p.DstPort != 443 {
+		t.Fatalf("ports: %d -> %d", p.SrcPort, p.DstPort)
+	}
+	if p.Protocol != ProtocolTCP {
+		t.Fatalf("protocol: %s", p.Protocol)
+	}
+	if p.Size != 1500 {
+		t.Fatalf("size: %d", p.Size)
+	}
+	if p.Source != "netflow" {
+		t.Fatalf("source: %s", p.Source)
+	}
+	if d.templateCount() != 1 {
+		t.Fatalf("templates: %d", d.templateCount())
+	}
+}
+
+func TestNetflowDecoder_RejectsNonV9(t *testing.T) {
+	d := newNetflowDecoder()
+	payload := make([]byte, 20)
+	binary.BigEndian.PutUint16(payload[0:2], 5)
+	_, err := d.decodePacket(net.IPv4(1, 2, 3, 4), payload)
+	if err == nil {
+		t.Fatal("expected error for v5")
+	}
+}
+
+func TestListHostAddresses_IncludesWildcard(t *testing.T) {
+	addrs, err := ListHostAddresses()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) == 0 || addrs[0].IP != "0.0.0.0" {
+		t.Fatalf("expected 0.0.0.0 first, got %#v", addrs)
+	}
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -87,6 +87,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -380,6 +381,23 @@
       "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==",
       "dev": true
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.15.18",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
@@ -396,6 +414,159 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/linux-loong64": {
       "version": "0.15.18",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
@@ -410,6 +581,244 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -644,9 +1053,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -664,9 +1070,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -684,9 +1087,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -704,9 +1104,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -724,9 +1121,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -744,9 +1138,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,6 +1268,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1183,6 +1575,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -2277,9 +2670,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2301,9 +2691,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2325,9 +2712,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2349,9 +2733,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2694,6 +3075,7 @@
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.10.1.tgz",
       "integrity": "sha512-wjKJXawhTUxuyKIuwE3jK05eBh5I4GKy+YrRVniURFRkK7pYEvRvnV41dEqz6owSXav/YMXdG5783YDJeamiow==",
+      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",
@@ -2731,6 +3113,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -2888,6 +3271,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2896,6 +3280,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -3432,6 +3817,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3549,6 +3935,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.11.tgz",
       "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",
@@ -3698,6 +4085,40 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
@@ -3754,6 +4175,7 @@
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -4034,6 +4456,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -4242,6 +4665,12 @@
       "integrity": "sha512-RpfLEtTlyIxeNPGKcokS+p3BZII/Q3bYxryFRglh5H3A3T8q9fsLYm72VYAMEOOIBLEa8o93kFLiBDUWKrwXZA==",
       "dev": true
     },
+    "@esbuild/aix-ppc64": {
+      "version": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "dev": true,
+      "optional": true
+    },
     "@esbuild/android-arm": {
       "version": "0.15.18",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
@@ -4249,10 +4678,148 @@
       "dev": true,
       "optional": true
     },
+    "@esbuild/android-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "dev": true,
+      "optional": true
+    },
     "@esbuild/linux-loong64": {
       "version": "0.15.18",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
       "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openharmony-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
       "dev": true,
       "optional": true
     },
@@ -4524,6 +5091,7 @@
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4729,6 +5297,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
       "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5628,6 +6197,7 @@
       "version": "8.10.1",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.10.1.tgz",
       "integrity": "sha512-wjKJXawhTUxuyKIuwE3jK05eBh5I4GKy+YrRVniURFRkK7pYEvRvnV41dEqz6owSXav/YMXdG5783YDJeamiow==",
+      "peer": true,
       "requires": {
         "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",
@@ -5646,6 +6216,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -5721,12 +6292,14 @@
     "react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true
     },
     "react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "requires": {
         "scheduler": "^0.26.0"
       }
@@ -6101,7 +6674,8 @@
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
           "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -6176,6 +6750,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.11.tgz",
       "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",
@@ -6224,6 +6799,18 @@
         "why-is-node-running": "^2.3.0"
       },
       "dependencies": {
+        "@esbuild/android-arm": {
+          "version": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+          "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+          "dev": true,
+          "optional": true
+        },
+        "@esbuild/linux-loong64": {
+          "version": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+          "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+          "dev": true,
+          "optional": true
+        },
         "@vitest/mocker": {
           "version": "4.1.10",
           "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
@@ -6255,6 +6842,7 @@
           "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
           "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
           "dev": true,
+          "peer": true,
           "requires": {
             "fsevents": "~2.3.3",
             "lightningcss": "^1.33.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { useWindowStore } from './stores/windowStore'
 import { RendererSelector } from './components/RendererSelector'
 import { CaptureContext } from './components/MinimalGraph'
 import { SettingsPanel } from './components/SettingsPanel' // Direct import
+import type { NetFlowHostAddress, NetFlowListenerStatus } from './components/SettingsPanel'
 import { UnifiedDebugPanel } from './components/UnifiedDebugPanel'
 import { PerformanceTestData } from './components/PerformanceTestData'
 // import { IPDebugPage } from './components/IPDebugPage'  // Using lazy loading instead
@@ -45,8 +46,13 @@ const LoadingFallback = () => (
 
 export const App = memo(() => {
   // --- State Declarations ---
-  const [captureMode, setCaptureMode] = useState<'simulated' | 'real' | 'zeek' | 'waiting'>('simulated');
+  const [captureMode, setCaptureMode] = useState<'simulated' | 'real' | 'zeek' | 'netflow' | 'waiting'>('simulated');
   const [zeekTcpAddr, setZeekTcpAddr] = useState<string>(':4777');
+  const [netflowAddresses, setNetflowAddresses] = useState<NetFlowHostAddress[]>([]);
+  const [netflowBindIP, setNetflowBindIP] = useState<string>('0.0.0.0');
+  const [netflowPort, setNetflowPort] = useState<number>(2055);
+  const [netflowStatus, setNetflowStatus] = useState<NetFlowListenerStatus | null>(null);
+  const [netflowBusy, setNetflowBusy] = useState(false);
   const [interfaces, setInterfaces] = useState<{ name: string; description: string }[]>([]);
   const [selectedInterface, setSelectedInterface] = useState<string>('');
   const [currentRenderer, setCurrentRenderer] = useState('canvas');
@@ -98,6 +104,9 @@ export const App = memo(() => {
     if (captureMode === 'zeek') {
       const addr = zeekTcpAddr.trim() || ':4777';
       return `${wsBase}/ws?zeek_tcp=${encodeURIComponent(addr)}`;
+    }
+    if (captureMode === 'netflow') {
+      return `${wsBase}/ws?netflow=1`;
     }
     if (captureMode === 'simulated') {
       return `${wsBase}/ws`;
@@ -287,6 +296,54 @@ export const App = memo(() => {
     
     fetchInterfaces();
   }, [captureMode]);
+
+  // NetFlow: load host IPs + poll listener status while in NetFlow mode
+  useEffect(() => {
+    if (captureMode !== 'netflow') return;
+
+    let cancelled = false;
+    const apiBaseUrl = getApiBaseUrl();
+
+    const refreshAddresses = async () => {
+      try {
+        const res = await fetch(`${apiBaseUrl}/api/netflow/addresses`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as NetFlowHostAddress[];
+        if (cancelled) return;
+        setNetflowAddresses(data);
+        setNetflowBindIP((current) => {
+          if (data.length && !data.some((a) => a.ip === current)) {
+            return data[0].ip;
+          }
+          return current;
+        });
+      } catch (err) {
+        logger.warn('Failed to load NetFlow bind addresses:', err);
+      }
+    };
+
+    const refreshStatus = async () => {
+      try {
+        const res = await fetch(`${apiBaseUrl}/api/netflow/status`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as NetFlowListenerStatus;
+        if (cancelled) return;
+        setNetflowStatus(data);
+        if (data.bind_ip) setNetflowBindIP(data.bind_ip);
+        if (data.port) setNetflowPort(data.port);
+      } catch (err) {
+        logger.warn('Failed to load NetFlow status:', err);
+      }
+    };
+
+    refreshAddresses();
+    refreshStatus();
+    const id = window.setInterval(refreshStatus, 2000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [captureMode]);
   
   logger.log(`🌐 WebSocket URL updated: ${wsUrl || 'none - waiting for settings'} (mode: ${captureMode}, interface: ${selectedInterface})`);
 
@@ -311,21 +368,23 @@ export const App = memo(() => {
     const serverUiMode =
       actualCaptureMode === 'zeek_conn'
         ? 'zeek'
-        : actualCaptureMode === 'unknown' || actualCaptureMode === 'waiting'
-          ? null
-          : (actualCaptureMode as 'simulated' | 'real');
+        : actualCaptureMode === 'netflow_v9'
+          ? 'netflow'
+          : actualCaptureMode === 'unknown' || actualCaptureMode === 'waiting'
+            ? null
+            : (actualCaptureMode as 'simulated' | 'real');
     // Only update if this is not a user-initiated change and there's a meaningful difference
     if (
       serverUiMode !== null &&
       serverUiMode !== captureMode &&
       !userInitiatedChangeRef.current
     ) {
-      // Don't let hook "simulated" (reconnect/error) stomp an explicit Zeek selection before server mode arrives
-      if (captureMode === 'zeek' && serverUiMode === 'simulated') {
+      // Don't let hook "simulated" (reconnect/error) stomp an explicit Zeek/NetFlow selection before server mode arrives
+      if ((captureMode === 'zeek' || captureMode === 'netflow') && serverUiMode === 'simulated') {
         return;
       }
       logger.log(`📡 Server reported capture mode: ${actualCaptureMode}, updating local state`);
-      setCaptureMode(serverUiMode === 'zeek' ? 'zeek' : serverUiMode);
+      setCaptureMode(serverUiMode);
     }
   }, [actualCaptureMode, captureMode]);
   
@@ -353,12 +412,14 @@ export const App = memo(() => {
       document.title = 'Network Visualizer - SIMULATION';
     } else if (actualCaptureMode === 'zeek_conn') {
       document.title = 'Network Visualizer - ZEEK CONN';
+    } else if (actualCaptureMode === 'netflow_v9') {
+      document.title = 'Network Visualizer - NETFLOW V9';
     } else {
       document.title = 'Network Visualizer';
     }
   }, [actualCaptureMode]);
   
-  const handleCaptureModeChange = (mode: 'simulated' | 'real' | 'zeek') => {
+  const handleCaptureModeChange = (mode: 'simulated' | 'real' | 'zeek' | 'netflow') => {
     logger.log("🔄 User switching mode to:", mode);
     
     // Prevent multiple rapid calls
@@ -380,6 +441,49 @@ export const App = memo(() => {
       userInitiatedChangeRef.current = false;
     }, 2000);
   }
+
+  const handleNetflowStart = async () => {
+    setNetflowBusy(true);
+    try {
+      const apiBaseUrl = getApiBaseUrl();
+      const res = await fetch(`${apiBaseUrl}/api/netflow/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ip: netflowBindIP || '0.0.0.0', port: netflowPort || 2055 }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        const msg = data?.error || `HTTP ${res.status}`;
+        logger.warn('NetFlow start failed:', msg);
+        if (data?.status) setNetflowStatus(data.status);
+        else setNetflowStatus((prev) => ({ ...(prev || {
+          state: 'error', bind_ip: netflowBindIP, port: netflowPort, listen_addr: '', templates: 0,
+          datagrams_ok: 0, datagrams_bad: 0, flows_ok: 0, subscribers: 0,
+        }), state: 'error', last_error: msg }));
+        return;
+      }
+      setNetflowStatus(data as NetFlowListenerStatus);
+    } catch (err) {
+      logger.warn('NetFlow start error:', err);
+    } finally {
+      setNetflowBusy(false);
+    }
+  };
+
+  const handleNetflowStop = async () => {
+    setNetflowBusy(true);
+    try {
+      const apiBaseUrl = getApiBaseUrl();
+      const res = await fetch(`${apiBaseUrl}/api/netflow/stop`, { method: 'POST' });
+      if (res.ok) {
+        setNetflowStatus((await res.json()) as NetFlowListenerStatus);
+      }
+    } catch (err) {
+      logger.warn('NetFlow stop error:', err);
+    } finally {
+      setNetflowBusy(false);
+    }
+  };
   
   const handleInterfaceSelect = (iface: string) => {
     logger.log("🔌 Interface selected:", iface);
@@ -424,7 +528,7 @@ export const App = memo(() => {
   // Simplified error handling - fall back to simulation only if not user-initiated
   useEffect(() => {
     if (status === 'error' && 
-        (captureMode === 'real' || captureMode === 'zeek') && 
+        (captureMode === 'real' || captureMode === 'zeek' || captureMode === 'netflow') && 
         !userInitiatedChangeRef.current) {
       logger.log('🔄 Capture failed, falling back to simulation mode');
       setCaptureMode('simulated');
@@ -448,9 +552,11 @@ export const App = memo(() => {
         captureMode:
           actualCaptureMode === 'zeek_conn'
             ? 'zeek'
-            : actualCaptureMode === 'real' || actualCaptureMode === 'simulated'
-              ? actualCaptureMode
-              : captureMode,
+            : actualCaptureMode === 'netflow_v9'
+              ? 'netflow'
+              : actualCaptureMode === 'real' || actualCaptureMode === 'simulated'
+                ? actualCaptureMode
+                : captureMode,
         captureInterface: selectedInterface 
       }}>
         {/* Black Hat NOC Header */}
@@ -488,6 +594,15 @@ export const App = memo(() => {
                 onInterfaceSelect={handleInterfaceSelect}
                 zeekTcpAddr={zeekTcpAddr}
                 onZeekTcpAddrChange={setZeekTcpAddr}
+                netflowAddresses={netflowAddresses}
+                netflowBindIP={netflowBindIP}
+                onNetflowBindIPChange={setNetflowBindIP}
+                netflowPort={netflowPort}
+                onNetflowPortChange={setNetflowPort}
+                netflowStatus={netflowStatus}
+                netflowBusy={netflowBusy}
+                onNetflowStart={handleNetflowStart}
+                onNetflowStop={handleNetflowStop}
                 wsPreviewUrl={wsUrl}
                 onMinimize={() => toggleSettings(false)}
               />

--- a/frontend/src/components/MinimalGraph.tsx
+++ b/frontend/src/components/MinimalGraph.tsx
@@ -5,7 +5,7 @@ import { createContext, useContext } from 'react'
 import { logger } from '../utils/logger'
 
 interface CaptureContextType {
-  captureMode: 'real' | 'simulated' | 'zeek' | 'unknown' | 'waiting';
+  captureMode: 'real' | 'simulated' | 'zeek' | 'netflow' | 'unknown' | 'waiting';
   captureInterface: string;
 }
 

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -10,14 +10,43 @@ type Tab = 'network' | 'physics';
 const WifiIcon = FiWifi as React.ElementType;
 const SlidersIcon = FiSliders as React.ElementType;
 
+export type NetFlowHostAddress = {
+  ip: string;
+  interface: string;
+  family: string;
+};
+
+export type NetFlowListenerStatus = {
+  state: string;
+  bind_ip: string;
+  port: number;
+  listen_addr: string;
+  templates: number;
+  datagrams_ok: number;
+  datagrams_bad: number;
+  flows_ok: number;
+  last_error?: string;
+  last_packet_at?: string;
+  subscribers: number;
+};
+
 export const SettingsPanel: React.FC<{
-  captureMode: 'simulated' | 'real' | 'zeek' | 'waiting';
-  onCaptureModeChange: (mode: 'simulated' | 'real' | 'zeek') => void;
+  captureMode: 'simulated' | 'real' | 'zeek' | 'netflow' | 'waiting';
+  onCaptureModeChange: (mode: 'simulated' | 'real' | 'zeek' | 'netflow') => void;
   interfaces: Array<{ name: string; description: string }>;
   selectedInterface: string;
   onInterfaceSelect: (iface: string) => void;
   zeekTcpAddr: string;
   onZeekTcpAddrChange: (addr: string) => void;
+  netflowAddresses: NetFlowHostAddress[];
+  netflowBindIP: string;
+  onNetflowBindIPChange: (ip: string) => void;
+  netflowPort: number;
+  onNetflowPortChange: (port: number) => void;
+  netflowStatus: NetFlowListenerStatus | null;
+  netflowBusy: boolean;
+  onNetflowStart: () => void;
+  onNetflowStop: () => void;
   /** Current frontend WebSocket URL (updates when mode / Zeek address changes). */
   wsPreviewUrl: string | null;
   onMinimize: () => void;
@@ -29,6 +58,15 @@ export const SettingsPanel: React.FC<{
   onInterfaceSelect,
   zeekTcpAddr,
   onZeekTcpAddrChange,
+  netflowAddresses,
+  netflowBindIP,
+  onNetflowBindIPChange,
+  netflowPort,
+  onNetflowPortChange,
+  netflowStatus,
+  netflowBusy,
+  onNetflowStart,
+  onNetflowStop,
   wsPreviewUrl,
   onMinimize
 }) => {
@@ -183,6 +221,13 @@ export const SettingsPanel: React.FC<{
               >
                 Zeek (TCP)
               </button>
+              <button
+                className={captureMode === 'netflow' ? 'active' : ''}
+                onClick={() => onCaptureModeChange('netflow')}
+                title="NetFlow v9 UDP collector"
+              >
+                NetFlow
+              </button>
             </div>
 
             {captureMode === 'zeek' && (
@@ -206,6 +251,146 @@ export const SettingsPanel: React.FC<{
                     font: 'var(--type-mono)',
                   }}
                 />
+              </div>
+            )}
+
+            {captureMode === 'netflow' && (
+              <div style={{ marginTop: '16px' }}>
+                <h3>NetFlow v9 collector</h3>
+                <p style={{ fontSize: '11px', opacity: 0.8, marginBottom: '10px', color: 'var(--text-muted)' }}>
+                  Point a third-party NetFlow v9 exporter at this host. Start the listener, then flows appear on the graph (slower than a span).
+                </p>
+
+                <label style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
+                  Listen IP
+                </label>
+                <select
+                  value={netflowBindIP}
+                  onChange={(e) => onNetflowBindIPChange(e.target.value)}
+                  disabled={netflowStatus?.state === 'listening' || netflowBusy}
+                  style={{
+                    width: '100%',
+                    padding: '8px 10px',
+                    marginBottom: '10px',
+                    background: 'var(--card, #141414)',
+                    border: 'var(--border-control, 1px solid rgba(255, 255, 255, 0.15))',
+                    borderRadius: 'var(--radius-sm, 6px)',
+                    color: 'var(--text-hi, #fff)',
+                    font: 'var(--type-mono)',
+                  }}
+                >
+                  {netflowAddresses.length === 0 && (
+                    <option value={netflowBindIP || '0.0.0.0'}>{netflowBindIP || '0.0.0.0'}</option>
+                  )}
+                  {netflowAddresses.map((a) => (
+                    <option key={`${a.ip}-${a.interface}`} value={a.ip}>
+                      {a.ip === '0.0.0.0'
+                        ? '0.0.0.0 — all interfaces'
+                        : `${a.ip} (${a.interface})`}
+                    </option>
+                  ))}
+                </select>
+
+                <label style={{ display: 'block', fontSize: '11px', color: 'var(--text-muted)', marginBottom: '4px' }}>
+                  UDP port
+                </label>
+                <input
+                  type="number"
+                  min={1024}
+                  max={65535}
+                  value={netflowPort}
+                  onChange={(e) => onNetflowPortChange(Number(e.target.value) || 2055)}
+                  disabled={netflowStatus?.state === 'listening' || netflowBusy}
+                  style={{
+                    width: '100%',
+                    padding: '8px 10px',
+                    marginBottom: '12px',
+                    background: 'var(--card, #141414)',
+                    border: 'var(--border-control, 1px solid rgba(255, 255, 255, 0.15))',
+                    borderRadius: 'var(--radius-sm, 6px)',
+                    color: 'var(--text-hi, #fff)',
+                    font: 'var(--type-mono)',
+                  }}
+                />
+
+                <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+                  <button
+                    type="button"
+                    onClick={onNetflowStart}
+                    disabled={netflowBusy || netflowStatus?.state === 'listening'}
+                    style={{
+                      flex: 1,
+                      padding: '8px 10px',
+                      background: netflowStatus?.state === 'listening' ? 'var(--wash-ok, rgba(34,197,94,0.15))' : 'var(--card, #141414)',
+                      border: 'var(--border-control, 1px solid rgba(255, 255, 255, 0.15))',
+                      borderRadius: 'var(--radius-sm, 6px)',
+                      color: 'var(--text-hi, #fff)',
+                      cursor: netflowBusy || netflowStatus?.state === 'listening' ? 'not-allowed' : 'pointer',
+                      opacity: netflowBusy || netflowStatus?.state === 'listening' ? 0.6 : 1,
+                    }}
+                  >
+                    Start listener
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onNetflowStop}
+                    disabled={netflowBusy || netflowStatus?.state === 'stopped' || !netflowStatus}
+                    style={{
+                      flex: 1,
+                      padding: '8px 10px',
+                      background: 'var(--card, #141414)',
+                      border: 'var(--border-control, 1px solid rgba(255, 255, 255, 0.15))',
+                      borderRadius: 'var(--radius-sm, 6px)',
+                      color: 'var(--text-hi, #fff)',
+                      cursor: netflowBusy || netflowStatus?.state === 'stopped' || !netflowStatus ? 'not-allowed' : 'pointer',
+                      opacity: netflowBusy || netflowStatus?.state === 'stopped' || !netflowStatus ? 0.6 : 1,
+                    }}
+                  >
+                    Stop listener
+                  </button>
+                </div>
+
+                <div
+                  style={{
+                    padding: '10px 12px',
+                    background: 'var(--surface-card, rgba(255,255,255,0.03))',
+                    border: 'var(--border-card, 1px solid rgba(255, 255, 255, 0.1))',
+                    borderRadius: 'var(--radius-sm, 6px)',
+                    font: 'var(--type-mono)',
+                    fontSize: '11px',
+                    color: 'var(--text-muted)',
+                  }}
+                >
+                  <div style={{ marginBottom: '4px' }}>
+                    Status:{' '}
+                    <span style={{
+                      color:
+                        netflowStatus?.state === 'listening'
+                          ? 'var(--signal-teal, #2dd4bf)'
+                          : netflowStatus?.state === 'error'
+                            ? 'var(--signal-red, #f87171)'
+                            : 'var(--text-hi, #fff)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.04em',
+                    }}>
+                      {netflowStatus?.state || 'stopped'}
+                    </span>
+                  </div>
+                  {netflowStatus?.listen_addr && (
+                    <div style={{ marginBottom: '4px' }}>Bind: {netflowStatus.listen_addr}</div>
+                  )}
+                  {netflowStatus && (
+                    <div style={{ marginBottom: '4px' }}>
+                      Flows: {netflowStatus.flows_ok} · Templates: {netflowStatus.templates} · Datagrams: {netflowStatus.datagrams_ok}
+                    </div>
+                  )}
+                  {netflowStatus?.last_packet_at && (
+                    <div style={{ marginBottom: '4px' }}>Last packet: {netflowStatus.last_packet_at}</div>
+                  )}
+                  {netflowStatus?.last_error && (
+                    <div style={{ color: 'var(--signal-red, #f87171)' }}>Error: {netflowStatus.last_error}</div>
+                  )}
+                </div>
               </div>
             )}
 

--- a/frontend/src/components/noc/NocHeader.tsx
+++ b/frontend/src/components/noc/NocHeader.tsx
@@ -6,7 +6,7 @@ export interface NocHeaderProps {
   currentRoute: string;
   status: string;
   error: string | null;
-  captureMode: 'simulated' | 'real' | 'zeek' | 'waiting';
+  captureMode: 'simulated' | 'real' | 'zeek' | 'netflow' | 'waiting';
   showSettings: boolean;
   onToggleSettings: () => void;
   showDebug?: boolean;
@@ -21,6 +21,7 @@ const MODE_LABELS: Record<string, { label: string; level: 'ok' | 'info' | 'waiti
   real: { label: 'LIVE CAPTURE', level: 'ok' },
   simulated: { label: 'SIMULATED TRAFFIC', level: 'info' },
   zeek: { label: 'ZEEK SENSOR', level: 'info' },
+  netflow: { label: 'NETFLOW V9', level: 'info' },
   waiting: { label: 'WAITING FOR STREAM', level: 'waiting' },
 };
 

--- a/frontend/src/components/noc/NocStatusBar.tsx
+++ b/frontend/src/components/noc/NocStatusBar.tsx
@@ -14,6 +14,7 @@ const CAPTURE_SOURCE_LABELS: Record<string, { label: string; level: 'ok' | 'info
   real: { label: 'LIVE INTERFACE', level: 'ok' },
   simulated: { label: 'SIMULATION GENERATOR', level: 'info' },
   zeek: { label: 'ZEEK SENSOR STREAM', level: 'info' },
+  netflow: { label: 'NETFLOW V9 COLLECTOR', level: 'info' },
   pcap_replay: { label: 'PCAP REPLAY', level: 'info' },
 };
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -5,7 +5,7 @@ import { getWebSocketUrl } from '../utils/websocketUtils';
 import { logger } from '../utils/logger';
 
 type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error' | 'waiting';
-type CaptureMode = 'real' | 'simulated' | 'zeek_conn' | 'unknown' | 'waiting';
+type CaptureMode = 'real' | 'simulated' | 'zeek_conn' | 'netflow_v9' | 'unknown' | 'waiting';
 
 interface WebSocketState {
   status: ConnectionStatus;
@@ -95,6 +95,8 @@ export const useWebSocket = (url: string | null): WebSocketState => {
           let guess: CaptureMode = 'simulated';
           if (url.includes('zeek_tcp')) {
             guess = 'zeek_conn';
+          } else if (url.includes('netflow')) {
+            guess = 'netflow_v9';
           } else if (url.includes('interface=')) {
             guess = 'real';
           }


### PR DESCRIPTION
## Summary
- Adds a process-wide NetFlow v9 UDP collector so third-party exporters can feed the same graph pipeline as span/sim/Zeek (`source: "netflow"`).
- Exposes `/api/netflow/addresses|status|start|stop` and a Settings → Capture Mode → **NetFlow** panel with bind IP (host addresses), UDP port, Start/Stop, and live listener status.
- WebSocket mode `?netflow=1` subscribes clients to the shared collector; includes unit tests for v9 decode and host address listing.

## Test plan
- [ ] Start backend + frontend; open Settings → **NetFlow**
- [ ] Confirm listen IP dropdown lists machine addresses including `0.0.0.0`
- [ ] Start listener on port `2055`; status shows **LISTENING**
- [ ] Point a NetFlow v9 exporter at the bind IP:port and confirm hosts/flows appear on the graph
- [ ] Stop listener; status returns to **STOPPED** and new flows stop arriving
- [ ] Switch back to Simulated/Real/Zeek and confirm those modes still work
- [ ] `go test ./...` in `backend` and `npm run test` / `npm run build` in `frontend`


Made with [Cursor](https://cursor.com)